### PR TITLE
Don't show blog/entry if :awestruct-hidden is true

### DIFF
--- a/_ext/relative_template.atom.haml
+++ b/_ext/relative_template.atom.haml
@@ -21,28 +21,29 @@
     %logo= "#{site.base_url}/headerFooter/optaPlannerLogo200px.png"
 
     - for entry in page.entries
-      %entry
-        %id #{site.base_url}#{entry.url}
-        %title= escape_once( entry.title )
-        %updated= entry.input_mtime.xmlschema
-        %published= entry.date.xmlschema
-        %link{:rel=>"alternate", :type=>"text/html", :href=>"#{site.base_url}#{entry.url}" }
-        - if ( not entry.author.nil? )
-          %author
-            - if ( defined?( entry.author.name ) )
-              %name= entry.author.name
-              - if ( entry.author.email )
-                %email= entry.author.email
-            - else
-              %name= entry.author
-        - if ( not entry.tags.nil? )
-          - for tag in entry.tags
-            %category{:term=>"#{tag}"}
-        %summary
-          #{summarize( html_to_text( entry.content ).strip, 50 )}
-        %content{:type=>'html'}
-          -# Trick to make images work from blog posts work in the atom feed
-          - default_imagesdir = site.asciidoctor.attributes['imagesdir']
-          - site.asciidoctor.attributes['imagesdir'] = relative(Pathname.new(entry.output_path).parent.to_s)
-          = clean_html( html_escape( fully_qualify_urls( site.base_url, find_and_preserve( entry.content ) ) ) )
-          - site.asciidoctor.attributes['imagesdir'] = default_imagesdir
+      - if !entry.hidden
+        %entry
+          %id #{site.base_url}#{entry.url}
+          %title= escape_once( entry.title )
+          %updated= entry.input_mtime.xmlschema
+          %published= entry.date.xmlschema
+          %link{:rel=>"alternate", :type=>"text/html", :href=>"#{site.base_url}#{entry.url}" }
+          - if ( not entry.author.nil? )
+            %author
+              - if ( defined?( entry.author.name ) )
+                %name= entry.author.name
+                - if ( entry.author.email )
+                  %email= entry.author.email
+              - else
+                %name= entry.author
+          - if ( not entry.tags.nil? )
+            - for tag in entry.tags
+              %category{:term=>"#{tag}"}
+          %summary
+            #{summarize( html_to_text( entry.content ).strip, 50 )}
+          %content{:type=>'html'}
+            -# Trick to make images work from blog posts work in the atom feed
+            - default_imagesdir = site.asciidoctor.attributes['imagesdir']
+            - site.asciidoctor.attributes['imagesdir'] = relative(Pathname.new(entry.output_path).parent.to_s)
+            = clean_html( html_escape( fully_qualify_urls( site.base_url, find_and_preserve( entry.content ) ) ) )
+            - site.asciidoctor.attributes['imagesdir'] = default_imagesdir

--- a/_partials/latestBlogPosts.html.haml
+++ b/_partials/latestBlogPosts.html.haml
@@ -3,13 +3,14 @@
   .panel-body
     %ul.list-unstyled
       - for post in site.posts[0,7]
-        %li(style="margin-bottom: 10px;")
-          .title
-            %a{:href => relative(post.url, page.outputPage)}
-              = post.title
-          .small
-            = post.date.strftime('%a %-d %B %Y')
-          = partial('userBadge.html.haml', :outputPage => page, :userId => post.author, :mode => 'inline')
+        - if !post.hidden
+          %li(style="margin-bottom: 10px;")
+            .title
+              %a{:href => relative(post.url, page.outputPage)}
+                = post.title
+            .small
+              = post.date.strftime('%a %-d %B %Y')
+            = partial('userBadge.html.haml', :outputPage => page, :userId => post.author, :mode => 'inline')
     .small.pull-right
       %a{:href => relative("/blog/archive.html", page.outputPage)}
         Archive

--- a/blog/archive.html.haml
+++ b/blog/archive.html.haml
@@ -7,11 +7,12 @@ priority: 0.1
 %h1 #{page.title}
 %ul
   - for post in site.posts
-    %li(style="margin-top: 10px;")
-      %a{:href => relative(post.url)}
-        = post.title
-      .small
-        = post.date.strftime('%a  %-d %B %Y')
-      = partial('userBadge.html.haml', :outputPage => page, :userId => post.author, :mode => 'inline')
+    - if !post.hidden
+      %li(style="margin-top: 10px;")
+        %a{:href => relative(post.url)}
+          = post.title
+        .small
+          = post.date.strftime('%a  %-d %B %Y')
+        = partial('userBadge.html.haml', :outputPage => page, :userId => post.author, :mode => 'inline')
 :asciidoc
   For older posts, see http://blog.athico.com/search/label/planner[the old blog].

--- a/blog/index.html.haml
+++ b/blog/index.html.haml
@@ -11,23 +11,24 @@ priority: 1.0
 - page.priority = "0.1" if !page.selected_tag.nil?
 %h1 #{page.title}
 - for post in page.posts
-  -# Trick to make images work from blog posts work for the aggregator blog page
-  - default_imagesdir = site.asciidoctor.attributes['imagesdir']
-  - site.asciidoctor.attributes['imagesdir'] = relative(Pathname.new(post.output_path).parent.to_s)
-  %h2.title(style="border-bottom: 1px solid #eee;")
-    %a{:href => relative(post.url, page)}
-      = post.title
-  %div(style="margin-bottom: 10px;")
-    .pull-right
-      %p(style="text-align: right;") #{post.date.strftime('%a %-d %B %Y')}
-    = partial('userBadge.html.haml', :outputPage => page, :userId => post.author, :mode => 'inline')
-  %p
-    = summarize(html_to_text(post.content).strip, 50)
-  %p
-    %a{:href => relative(post.url, page)}
-      Read more ...
-  - site.asciidoctor.attributes['imagesdir'] = default_imagesdir
-  %hr(style="border-color: #000;")
+  - if !post.hidden
+    -# Trick to make images work from blog posts work for the aggregator blog page
+    - default_imagesdir = site.asciidoctor.attributes['imagesdir']
+    - site.asciidoctor.attributes['imagesdir'] = relative(Pathname.new(post.output_path).parent.to_s)
+    %h2.title(style="border-bottom: 1px solid #eee;")
+      %a{:href => relative(post.url, page)}
+        = post.title
+    %div(style="margin-bottom: 10px;")
+      .pull-right
+        %p(style="text-align: right;") #{post.date.strftime('%a %-d %B %Y')}
+      = partial('userBadge.html.haml', :outputPage => page, :userId => post.author, :mode => 'inline')
+    %p
+      = summarize(html_to_text(post.content).strip, 50)
+    %p
+      %a{:href => relative(post.url, page)}
+        Read more ...
+    - site.asciidoctor.attributes['imagesdir'] = default_imagesdir
+    %hr(style="border-color: #000;")
 %ul.pager
   %li.previous{:class => ('disabled' unless page.posts.previous_page)}
     %a{:href => (page.posts.previous_page ? relative(page.posts.previous_page.url, page) : '#')}


### PR DESCRIPTION
Add the ability to have blogs ready but not visible from the landing page or the archive by adding `:awestruct-hidden: true` for these components.