### PR TITLE
PLANNER-1599 N&N Sequential Subpillars

### DIFF
--- a/download/releaseNotes/releaseNotes7.adoc
+++ b/download/releaseNotes/releaseNotes7.adoc
@@ -5,6 +5,27 @@
 :awestruct-release_notes_version: 7
 :awestruct-release_notes_version_qualifier: Final
 
+== New and noteworthy: Engine 7.27.0.Final (NOT YET RELEASED)
+
+=== Pillar moves are faster
+
+`PillarSwapMove` and `PillarChangeMove` have seen improvements under the hood and are now faster. We have observed
+increases in throughput of around 5 %. Your mileage may vary.
+
+=== Sequential sub pillars
+
+`PillarSwapMove` and `PillarChangeMove` now support sequential sub pillars, bringing better scores on examples with
+clear entity succession, such as with shifts of a nurse. The simplest configuration of sequential sub pillars looks like
+this:
+
+[source,xml,options="nowrap"]
+----
+<pillar...MoveSelector>
+  <subPillarType>SEQUENCE</subPillarType>
+</pillar...MoveSelector>
+----
+
+For more information, please refer to link:/learn/documentation.html[Documentation].
 
 == New and noteworthy: Engine 7.20.0.Final
 

--- a/download/releaseNotes/releaseNotes7.adoc
+++ b/download/releaseNotes/releaseNotes7.adoc
@@ -9,14 +9,14 @@
 
 === Pillar moves are faster
 
-`PillarSwapMove` and `PillarChangeMove` have seen improvements under the hood and are now faster. We have observed
-increases in throughput of around 5 %. Your mileage may vary.
+`PillarSwapMove` and `PillarChangeMove` improved under the hood and are now faster. We observed increases in throughput
+of around 5 %. Your mileage may vary.
 
 === Sequential sub pillars
 
 `PillarSwapMove` and `PillarChangeMove` now support sequential sub pillars, bringing better scores on examples with
-clear entity succession, such as with shifts of a nurse. The simplest configuration of sequential sub pillars looks like
-this:
+clear entity succession, such as employee shift rostering. The simplest configuration of sequential sub pillars looks
+like this:
 
 [source,xml,options="nowrap"]
 ----
@@ -25,7 +25,7 @@ this:
 </pillar...MoveSelector>
 ----
 
-For more information, please refer to link:/learn/documentation.html[Documentation].
+For more information, please refer to link:../../learn/documentation.html[Documentation].
 
 == New and noteworthy: Engine 7.20.0.Final
 

--- a/download/upgradeRecipe/upgradeRecipe7.adoc
+++ b/download/upgradeRecipe/upgradeRecipe7.adoc
@@ -2748,3 +2748,35 @@ rule "Language diversity"
         scoreHolder.reward(kcontext);
 end
 ----
+
+== From 7.26.0.Final to 7.27.0.Final
+
+=== `subPilarEnabled` property is deprecated
+
+The `subPillarEnabled` property has been deprecated and replaced by a new property, `subPillarType`. The default value
+for the deprecated property has always been `true`. The new way to manually override that to `false` is as follows.
+
+Before in `*SolverConfig.xml` and `*BenchmarkConfig.xml`:
+[source, xml]
+----
+      <pillar...MoveSelector>
+        ...
+        <pillarSelector>
+          <subPillarEnabled>false</subPillarEnabled>
+          ...
+        </pillarSelector>
+        ...
+      </pillar...MoveSelector>
+----
+
+After in `*SolverConfig.xml` and `*BenchmarkConfig.xml`:
+[source, xml]
+----
+      <pillar...MoveSelector>
+        <subPillarType>NONE</subPillarType>
+        <pillarSelector>
+          ...
+        </pillarSelector>
+        ...
+      </pillar...MoveSelector>
+----

--- a/download/upgradeRecipe/upgradeRecipe7.adoc
+++ b/download/upgradeRecipe/upgradeRecipe7.adoc
@@ -2751,10 +2751,11 @@ end
 
 == From 7.26.0.Final to 7.27.0.Final
 
-=== `subPilarEnabled` property is deprecated
+=== Property `subPilarEnabled` in move selector configuration is deprecated
 
-The `subPillarEnabled` property has been deprecated and replaced by a new property, `subPillarType`. The default value
-for the deprecated property has always been `true`. The new way to manually override that to `false` is as follows.
+The `subPillarEnabled` property on `PillarSwapMoveSelector` and `PillarChangeMoveSelector` has been deprecated and
+replaced by a new property, `subPillarType`. The default value for the deprecated property has always been `true`. The
+new way to manually override that to `false` is as follows.
 
 Before in `*SolverConfig.xml` and `*BenchmarkConfig.xml`:
 [source, xml]


### PR DESCRIPTION
@ge0ffrey Review please.

Also, it would become much more convenient if N&N would become part of the documentation. Why?

- When I'm updating docs, it becomes trivial to update N&N in the same PR.
- Other projects have realized this as well, incl. [AssertJ ](https://assertj.github.io/doc/#release-notes) or our own [Drools](https://docs.drools.org/7.25.0.Final/drools-docs/html_single/#droolsreleasenoteschapter).
- That's where I'm looking for it.