### PR TITLE
Apply max-width to all Youtube videos to avoid content wider that screen

### DIFF
--- a/blog/2013-10-11-WillSkynetControlOurSchedule.adoc
+++ b/blog/2013-10-11-WillSkynetControlOurSchedule.adoc
@@ -52,9 +52,7 @@ image::skynet5.png[]
 
 If you want to see this in action, skip to the end of this video:
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/4meWIhPRVn8" frameborder="0" allowfullscreen></iframe>
-+++
+video::4meWIhPRVn8[youtube]
 
 == The human must remain in control
 

--- a/blog/2014-04-17-PutTheUserInControlOfTheScoreConstraints.adoc
+++ b/blog/2014-04-17-PutTheUserInControlOfTheScoreConstraints.adoc
@@ -110,9 +110,7 @@ Before sending this file to the users, we hide row 2 to 11, so the user isn't ex
 
 See this video for a detailed demonstration:
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/K084NKRZqkg" frameborder="0" allowfullscreen></iframe>
-+++
+video::K084NKRZqkg[youtube]
 
 Note that a _decision table_ is more powerful then a _data driven DRL rule_: the user decides which conditions to apply.
 The other conditions are not even included (which is faster than checking them against default values).

--- a/blog/2015-05-19-OptaPlannerOnAndroid.adoc
+++ b/blog/2015-05-19-OptaPlannerOnAndroid.adoc
@@ -76,9 +76,7 @@ dependencies {
 I created an OptaPlanner Android application named _Vehicle Routing Problem_. It is based on Vehicle routing
 application from OptaPlanner Examples. See this video for a detailed demonstration:
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/WpfjS6I5HGg" frameborder="0" allowfullscreen></iframe>
-+++
+video::WpfjS6I5HGg[youtube]
 
 https://play.google.com/store/apps/details?id=org.tomasdavid.vehicleroutingproblem[Get this app from the Google Play app store now.]
 The source code is https://github.com/tomasdavidorg/android-vehicle-routing-problem[on GitHub].

--- a/blog/2015-10-01-SneakPeekAtOptaPlannerWorkbench.adoc
+++ b/blog/2015-10-01-SneakPeekAtOptaPlannerWorkbench.adoc
@@ -14,9 +14,7 @@ Let's take a sneak peek at that.
 
 == Video
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/XB1_juPoWiU?rel=0" frameborder="0" allowfullscreen></iframe>
-+++
+video::XB1_juPoWiU[youtube]
 
 == The CloudBalancing example
 

--- a/blog/2015-12-01-TimeSchedulingDesignPatterns.adoc
+++ b/blog/2015-12-01-TimeSchedulingDesignPatterns.adoc
@@ -25,9 +25,7 @@ image::assigningTimeToPlanningEntities.png[]
 In the _Timeslot_ pattern, all entities have *the same duration*. For example in course timetabling, all lecture take 1 hour.
 Each lecture is assigned to 1 room and 1 timeslot.
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/4meWIhPRVn8?rel=0" frameborder="0" allowfullscreen></iframe>
-+++
+video::4meWIhPRVn8[youtube]
 
 == TimeGrain pattern
 
@@ -36,9 +34,7 @@ For most human activities, scheduling on second or subsecond accuracy is pointle
 for example in meeting scheduling, expecting people to show up at exactly 3 seconds after 9 o'clock for a meeting is overly optimistic.
 Therefore scheduling on such a fine-grained accuracy would actually be counter-productive.
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/wLK2-4IGtWY?rel=0" frameborder="0" allowfullscreen></iframe>
-+++
+video::wLK2-4IGtWY[youtube]
 
 == Chained Through Time pattern
 
@@ -46,9 +42,7 @@ In the _Chained Through Time_ pattern, a person or machine continuously works on
 For example in vehicle routing with time windows, each vehicle drives from customer to customer, so it handles 1 customer at a time.
 The starting time of each planning entity is calculated based on the ending time of the previous planning entity.
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/BxO3UFmtAPg?rel=0" frameborder="0" allowfullscreen></iframe>
-+++
+video::BxO3UFmtAPg[youtube]
 
 This pattern also works well for scheduling TV advertisements, because each advertisement starts when the previous ends.
 

--- a/blog/2017-08-18-OptimizeYourProblemsUsingKieServerPart.adoc
+++ b/blog/2017-08-18-OptimizeYourProblemsUsingKieServerPart.adoc
@@ -138,9 +138,7 @@ documentation for more details on the API.
 Optionally try out KIE Workbench, which integrates with the KIE Server.
 The following video demonstrates the process of setting up a Workbench example and optimizing it using the KIE Server.
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/bpBGujiMCAs?ecver=1" frameborder="0" allowfullscreen></iframe>
-+++
+video::bpBGujiMCAs[youtube]
 
 == Conclusion
 

--- a/blog/2018-02-19-SchedulingVoxxedDaysZurich2018.adoc
+++ b/blog/2018-02-19-SchedulingVoxxedDaysZurich2018.adoc
@@ -92,6 +92,4 @@ _This article was originally published on https://developers.redhat.com/blog/201
 
 == Related video
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/R0JizNdxEjU" frameborder="0" allowfullscreen></iframe>
-+++
+video::R0JizNdxEjU[youtube]

--- a/blog/2018-05-23-BehindTheScenesOfRedHatSummitScheduling.adoc
+++ b/blog/2018-05-23-BehindTheScenesOfRedHatSummitScheduling.adoc
@@ -125,6 +125,4 @@ If you're organizing a conference, take a look at the video below to try it out 
 
 == Related video
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/R0JizNdxEjU" frameborder="0" allowfullscreen></iframe>
-+++
+video::R0JizNdxEjU[youtube]

--- a/blog/2018-08-21-UnitTestingConstraintsWithBusinessInputFromExcelOrLibreOffice.adoc
+++ b/blog/2018-08-21-UnitTestingConstraintsWithBusinessInputFromExcelOrLibreOffice.adoc
@@ -110,6 +110,4 @@ To test score rules in an `xlsx` file:
 
 https://www.optaplanner.org/blog/2018/02/19/SchedulingVoxxedDaysZurich2018.html[Scheduling Voxxed Days Zurich 2018 with OptaPlanner]
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/R0JizNdxEjU" frameborder="0" allowfullscreen></iframe>
-+++
+video::R0JizNdxEjU[youtube]

--- a/blog/2019-05-09-RHSummit2019Part1.adoc
+++ b/blog/2019-05-09-RHSummit2019Part1.adoc
@@ -43,9 +43,7 @@ Deciding the order in which to fix them, as damage comes in concurrently, is dif
 Luckily, OptaPlanner schedules those mechanics for us.
 It reacts to health changes in real-time, as shown in this video:
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/Y4wyPU_B2gU" frameborder="0" allowfullscreen></iframe>
-+++
+video::Y4wyPU_B2gU[youtube]
 
 == The planning challenge
 
@@ -95,9 +93,7 @@ decreases their carbon footprint, which is great for the environment too!
 https://www.optaplanner.org/learn/useCases/vehicleRoutingProblem.html[Learn more about optimizing VRP's with OptaPlanner]
 or take a look at Jiri's latest demo of the https://github.com/kiegroup/optaweb-vehicle-routing[optaweb-vehicle-routing] reference architecture:
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/ylPEIf7Mc2M" frameborder="0" allowfullscreen></iframe>
-+++
+video::ylPEIf7Mc2M[youtube]
 
 
 == The real challenges
@@ -126,6 +122,4 @@ who can set up a show like no other!
 
 View the recording of our show:
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/FUu4kMc0PL8?start=5785" frameborder="0" allowfullscreen></iframe>
-+++
+video::FUu4kMc0PL8[youtube, start=5785]

--- a/blog/2019-05-09-RHSummit2019Part2.adoc
+++ b/blog/2019-05-09-RHSummit2019Part2.adoc
@@ -109,6 +109,4 @@ who can set up a show like no other!
 
 View the recording of our show:
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/FUu4kMc0PL8?start=5785" frameborder="0" allowfullscreen></iframe>
-+++
+video::FUu4kMc0PL8[youtube, start=5785]

--- a/blog/2019-05-09-RHSummit2019Part3.adoc
+++ b/blog/2019-05-09-RHSummit2019Part3.adoc
@@ -191,6 +191,4 @@ who can set up a show like no other!
 
 View the recording of our show:
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/FUu4kMc0PL8?start=5785" frameborder="0" allowfullscreen></iframe>
-+++
+video::FUu4kMc0PL8[youtube, start=5785]

--- a/download/releaseNotes/releaseNotes6.4.adoc
+++ b/download/releaseNotes/releaseNotes6.4.adoc
@@ -98,9 +98,7 @@ A ksession defined in `META-INF/kmodule.xml` can now be referenced from a Solver
 
 Assign meetings of different durations to starting times and rooms.
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/wLK2-4IGtWY?rel=0" frameborder="0" allowfullscreen></iframe>
-+++
+video::wLK2-4IGtWY[youtube]
 
 Also see the blog about
 https://www.optaplanner.org/blog/2015/12/01/TimeSchedulingDesignPatterns.html[time scheduling design patterns].
@@ -120,9 +118,7 @@ https://www.optaplanner.org/blog/2015/12/01/TimeSchedulingDesignPatterns.html[ti
 As https://www.optaplanner.org/blog/2015/10/01/SneakPeekAtOptaPlannerWorkbench.html[mentioned in our blog],
 we 've build first version of OptaPlanner Workbench and OptaPlanner Execution Server. Take a look at what it can do:
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/t8Qu9J2D2aA?rel=0" frameborder="0" allowfullscreen></iframe>
-+++
+video::t8Qu9J2D2aA[youtube]
 
 To try out OptaPlanner Workbench, link:../../download/download.html[download] and deploy the KIE Workbench war and create a user with the role `plannermgmt`.
 Note that a user with the `admin` role currently doesn't see OptaPlanner screens yet.

--- a/download/releaseNotes/releaseNotes7.adoc
+++ b/download/releaseNotes/releaseNotes7.adoc
@@ -277,9 +277,7 @@ Soft constraints:
 * Talk preferred room tag: If a talk has a preferred room tag, then it should be assigned to a room with that tag.
 * Talk undesired room tag: If a talk has a undesired room tag, then it should not be assigned to a room with that tag.
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/R0JizNdxEjU?rel=0" frameborder="0" allowfullscreen></iframe>
-+++
+video::R0JizNdxEjU[youtube]
 
 === Open the benchmark report automatically
 
@@ -578,9 +576,7 @@ use the new `ScoreVerifier` support classes in `optaplanner-test`.
 Assign tasks to employee and take into account required skills, affinity with the customer and task priority.
 This example also demonstrates real-time producing and consuming of tasks.
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/ksXjQ851RAU?rel=0" frameborder="0" allowfullscreen></iframe>
-+++
+video::ksXjQ851RAU[youtube]
 
 
 === Other Engine improvements

--- a/learn/rhpds/optaweb-employee-rostering.adoc
+++ b/learn/rhpds/optaweb-employee-rostering.adoc
@@ -6,9 +6,7 @@
 
 == Video instructions
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/3CvadujUN1k" frameborder="0" allowfullscreen></iframe>
-+++
+video::3CvadujUN1k[youtube]
 
 == Written instructions
 

--- a/learn/rhpds/optaweb-vehicle-routing.adoc
+++ b/learn/rhpds/optaweb-vehicle-routing.adoc
@@ -6,7 +6,7 @@
 
 == Video instructions
 
-video::ylPEIf7Mc2M[youtube,width=853,height=480]
+video::ylPEIf7Mc2M[youtube]
 
 == Written instructions
 

--- a/learn/useCases/cloudOptimization.adoc
+++ b/learn/useCases/cloudOptimization.adoc
@@ -26,6 +26,4 @@ It is written in 100% pure Java™, runs on any JVM and is available in link:../
 
 == Videos
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/xhCtuM-Hiic" frameborder="0" allowfullscreen></iframe>
-+++
+video::xhCtuM-Hiic[youtube]

--- a/learn/useCases/conferenceScheduling.adoc
+++ b/learn/useCases/conferenceScheduling.adoc
@@ -39,14 +39,8 @@ It is written in 100% pure Java™, runs on any JVM and is available in link:../
 
 == Videos
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/ykF8DjxhQJI" frameborder="0" allowfullscreen></iframe>
-+++
+video::ykF8DjxhQJI[youtube]
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/GnnMHkY6vKk" frameborder="0" allowfullscreen></iframe>
-+++
+video::GnnMHkY6vKk[youtube]
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/R0JizNdxEjU" frameborder="0" allowfullscreen></iframe>
-+++
+video::R0JizNdxEjU[youtube]

--- a/learn/useCases/employeeRostering.adoc
+++ b/learn/useCases/employeeRostering.adoc
@@ -29,10 +29,6 @@ It is written in 100% pure Java™, runs on any JVM and is available in link:../
 
 == Videos
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/3CvadujUN1k" frameborder="0" allowfullscreen></iframe>
-+++
+video::3CvadujUN1k[youtube]
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/7nPagqJK3bs" frameborder="0" allowfullscreen></iframe>
-+++
+video::7nPagqJK3bs[youtube]

--- a/learn/useCases/maintenanceScheduling.adoc
+++ b/learn/useCases/maintenanceScheduling.adoc
@@ -36,6 +36,4 @@ It is written in 100% pure Java™, runs on any JVM and is available in link:../
 
 == Videos
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/Y4wyPU_B2gU" frameborder="0" allowfullscreen></iframe>
-+++
+video::Y4wyPU_B2gU[youtube]

--- a/learn/useCases/schoolTimetabling.adoc
+++ b/learn/useCases/schoolTimetabling.adoc
@@ -35,10 +35,6 @@ It is written in 100% pure Java™, runs on any JVM and is available in link:../
 
 == Videos
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/4meWIhPRVn8" frameborder="0" allowfullscreen></iframe>
-+++
+video::4meWIhPRVn8[youtube]
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/u_bl6E7aiNY" frameborder="0" allowfullscreen></iframe>
-+++
+video::u_bl6E7aiNY[youtube]

--- a/learn/useCases/taskAssignmentOptimization.adoc
+++ b/learn/useCases/taskAssignmentOptimization.adoc
@@ -27,6 +27,4 @@ It is written in 100% pure Java™, runs on any JVM and is available in link:../
 
 == Videos
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/ksXjQ851RAU" frameborder="0" allowfullscreen></iframe>
-+++
+video::ksXjQ851RAU[youtube]

--- a/learn/useCases/vehicleRoutingProblem.adoc
+++ b/learn/useCases/vehicleRoutingProblem.adoc
@@ -60,18 +60,10 @@ image:integrationWithRealMaps.png[Integration with real maps]
 
 == Videos
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/eG_ky8jIRBk" frameborder="0" allowfullscreen></iframe>
-+++
+video::eG_ky8jIRBk[youtube]
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/ylPEIf7Mc2M" frameborder="0" allowfullscreen></iframe>
-+++
+video::ylPEIf7Mc2M[youtube]
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/BxO3UFmtAPg" frameborder="0" allowfullscreen></iframe>
-+++
+video::BxO3UFmtAPg[youtube]
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/4hp_Qg1hFgE" frameborder="0" allowfullscreen></iframe>
-+++
+video::4hp_Qg1hFgE[youtube]

--- a/learn/video.adoc
+++ b/learn/video.adoc
@@ -7,6 +7,7 @@
 See https://www.youtube.com/playlist?list=PLJY69IMbAdq0uKPnjtWXZ2x7KE1eWg3ns[Geoffrey's OptaPlanner playlist on YouTube]
 for a list of all videos.
 
-+++
-<iframe class="youtube" src="https://www.youtube.com/embed/videoseries?list=PLJY69IMbAdq0uKPnjtWXZ2x7KE1eWg3ns&showinfo=1" frameborder="0" allowfullscreen></iframe>
-+++
+// Video ID not needed for embedded list but the video:: macro needs a value.
+// Using an invalid video ID has the same effect as not using any and results
+// in showing the newest video in the playlist.
+video::dummy[youtube, list=PLJY69IMbAdq0uKPnjtWXZ2x7KE1eWg3ns]

--- a/website/optaplannerWebsite.css
+++ b/website/optaplannerWebsite.css
@@ -104,7 +104,7 @@ img {
     max-width: 100%;
 }
 
-iframe.youtube {
+iframe.youtube, .videoblock iframe {
     width: 853px;
     height: 480px;
     /* Mobile friendly: No content wider than screen */


### PR DESCRIPTION
Alternative to #172.

@ge0ffrey If you like this, I can apply the new syntax to all existing Youtube links. The advantage of the `video::` syntax is that you don't have to remember or copypaste the iframe code snippet with all required attributes. It's much simpler, produces the same result and you only need to the video ID.