### PR TITLE
Add make to Fedora's dependencies

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,12 +12,12 @@ Follow these instructions:
 
 ```
 # Optional: clean your system first.
-$ sudo dnf remove ruby rubygems rubygem-rake rubygem-bundler ruby-devel rpm-build gcc-c++
+$ sudo dnf remove ruby rubygems rubygem-rake rubygem-bundler ruby-devel rpm-build gcc-c++ make
 
 # Install ruby and other native rpm's
 # TODO Is rpm-build obsolete? It was once needed for ffi
 # TODO Is gcc-c++ obsolete? It was needed for eventmachine
-$ sudo dnf install ruby rubygems rubygem-rake rubygem-bundler ruby-devel rpm-build gcc-c++
+$ sudo dnf install ruby rubygems rubygem-rake rubygem-bundler ruby-devel rpm-build gcc-c++ make
 
 $ ruby --version
 ruby 2.4.3p205 (2017-12-14 revision 61247) [x86_64-linux]


### PR DESCRIPTION
When doing `rake setup` Make is required, and Make does not come installed by default in Fedora 31 (that or I somehow uninstalled make)