### PR TITLE
PLANNER-1748: Add optaweb-employee-rostering zip download links

### DIFF
--- a/_config/pom.yml
+++ b/_config/pom.yml
@@ -6,6 +6,7 @@ latestFinal:
 
   businessCentralWorkbenchWildFlyWar: https://download.jboss.org/drools/release/7.31.0.Final/business-central-7.31.0.Final-wildfly14.war
   kieExecutionServerZip: https://download.jboss.org/drools/release/7.31.0.Final/kie-server-distribution-7.31.0.Final.zip
+  optawebEmployeeRosteringDistributionZip: https://download.jboss.org/optaplanner/release/7.31.0.Final/employee-rostering-distribution-7.31.0.Final.zip
 
   engineDocumentationHtmlSingle: https://docs.optaplanner.org/7.31.0.Final/optaplanner-docs/html_single/index.html
   engineDocumentationPdf: https://docs.optaplanner.org/7.31.0.Final/optaplanner-docs/pdf/index.pdf
@@ -42,6 +43,7 @@ nightly:
   kieWorkbenchWildFlyWar: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie&a=business-central&v=7.32.0-SNAPSHOT&e=war&c=wildfly14
   kieExecutionServerJavaEE7: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.32.0-SNAPSHOT&e=war&c=ee7
   kieExecutionServerWebc: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.32.0-SNAPSHOT&e=war&c=webc
+  optawebEmployeeRosteringDistributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.employeerostering&a=employee-rostering-distribution&v=7.32.0-SNAPSHOT&e=zip
 
   engineDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-docs&v=7.32.0-SNAPSHOT&e=zip
   kieWorkbenchDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-wb-es-guide&v=7.32.0-SNAPSHOT&e=zip

--- a/download/download.html.haml
+++ b/download/download.html.haml
@@ -19,6 +19,8 @@ title: Download
     %a(href="#workbench" data-toggle="pill") Workbench
   %li
     %a(href="#execution-server" data-toggle="pill") Execution Server
+  %li
+    %a(href="#optaweb-employee-rostering" data-toggle="pill") OptaWeb Employee Rostering
 
 %div(class="tab-content download-tab-content")
   %div(id="engine" class="tab-pane fade in active")
@@ -106,6 +108,11 @@ title: Download
       ** #{site.pom.latestFinal.kieExecutionServerZip}[Any application server]
       ** License: link:../code/license.html[Apache Software License 2.0] - Date: #{site.pom.latestFinal.releaseDate.strftime('%a %-d %B %Y')}
       * For Red Hat subscription releases https://access.redhat.com/downloads[go to the product download site].
+  %div(id="optaweb-employee-rostering" class="tab-pane fade")
+    :asciidoc
+      * image:download.png[Download] *#{site.pom.latestFinal.optawebEmployeeRosteringDistributionZip}[Download OptaWeb Employee Rostering #{site.pom.latestFinal.version}]*
+      ** License: link:../code/license.html[Apache Software License 2.0] - Date: #{site.pom.latestFinal.releaseDate.strftime('%a %-d %B %Y')}
+      * For Red Hat subscription releases https://access.redhat.com/downloads[go to the product download site].
 
 :asciidoc
   [[NonFinalReleases]]
@@ -180,6 +187,8 @@ title: Download
     %a(href="#workbench-nightly" data-toggle="pill") Workbench
   %li
     %a(href="#execution-server-nightly" data-toggle="pill") Execution Server
+  %li
+    %a(href="#optaweb-employee-rostering-nightly" data-toggle="pill") OptaWeb Employee Rostering
 
 %div(class="tab-content download-tab-content")
   %div(id="engine-nightly" class="tab-pane fade in active")
@@ -194,6 +203,9 @@ title: Download
       * image:download.png[Download] *Download OptaPlanner Execution Server #{site.pom.nightly.version}*
       ** #{site.pom.nightly.kieExecutionServerJavaEE7}[JavaEE 7] -
       #{site.pom.nightly.kieExecutionServerWebc}[Web (Servlet) container]
+  %div(id="optaweb-employee-rostering-nightly" class="tab-pane fade")
+    :asciidoc
+      * image:download.png[Download] *#{site.pom.nightly.optawebEmployeeRosteringDistributionZip}[Download OptaWeb Employee Rostering #{site.pom.nightly.version}]*
 
 :asciidoc
   [[OlderReleases]]
@@ -206,6 +218,8 @@ title: Download
     %a(href="#workbench-older" data-toggle="pill") Workbench
   %li
     %a(href="#execution-server-older" data-toggle="pill") Execution Server
+  %li
+    %a(href="#optaweb-employee-rostering-older" data-toggle="pill") OptaWeb Employee Rostering
 
 %div(class="tab-content download-tab-content")
   %div(id="engine-older" class="tab-pane fade in active")
@@ -215,5 +229,8 @@ title: Download
     :asciidoc
       For older community releases, check https://download.jboss.org/drools/release/[the release archive].
   %div(id="execution-server-older" class="tab-pane fade")
+    :asciidoc
+      For older community releases, check https://download.jboss.org/drools/release/[the release archive].
+  %div(id="optaweb-employee-rostering-older" class="tab-pane fade")
     :asciidoc
       For older community releases, check https://download.jboss.org/drools/release/[the release archive].

--- a/download/download.html.haml
+++ b/download/download.html.haml
@@ -110,8 +110,9 @@ title: Download
       * For Red Hat subscription releases https://access.redhat.com/downloads[go to the product download site].
   %div(id="optaweb-employee-rostering" class="tab-pane fade")
     :asciidoc
-      * image:download.png[Download] *#{site.pom.latestFinal.optawebEmployeeRosteringDistributionZip}[Download OptaWeb Employee Rostering #{site.pom.latestFinal.version}]*
-      ** License: link:../code/license.html[Apache Software License 2.0] - Date: #{site.pom.latestFinal.releaseDate.strftime('%a %-d %B %Y')}
+      * Coming soon!
+-# * image:download.png[Download] *#{site.pom.latestFinal.optawebEmployeeRosteringDistributionZip}[Download OptaWeb Employee Rostering #{site.pom.latestFinal.version}]*
+-# ** License: link:../code/license.html[Apache Software License 2.0] - Date: #{site.pom.latestFinal.releaseDate.strftime('%a %-d %B %Y')}
       * For Red Hat subscription releases https://access.redhat.com/downloads[go to the product download site].
 
 :asciidoc

--- a/learn/documentation.html.haml
+++ b/learn/documentation.html.haml
@@ -58,8 +58,9 @@ title: Documentation
   %div(id="optaweb-vehicle-routing" class="tab-pane fade")
     :asciidoc
       * image:documentation.png[Documentation] OptaWeb Vehicle Routing reference manual #{site.pom.latestFinal.version}:
-        ** #{site.pom.latestFinal.optawebVehicleRoutingDocumentationHtmlSingle}[HTML Single] -
-        #{site.pom.latestFinal.optawebVehicleRoutingDocumentationPdf}[PDF]
+        ** Coming soon!
+-# ** #{site.pom.latestFinal.optawebVehicleRoutingDocumentationHtmlSingle}[HTML Single] -
+-# #{site.pom.latestFinal.optawebVehicleRoutingDocumentationPdf}[PDF]
 
       * Red Hat subscription documentation: Check https://access.redhat.com/documentation/[the customer portal].
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/PLANNER-1748

EDIT: Good to merge. When 7.32.Final is released and download links are ready, I will create a PR that uncomments the download links to be published on the website.