### PR TITLE
[PLANNER-1721] Remove all Workbench references; they are now obsolete

### DIFF
--- a/_config/pom.yml
+++ b/_config/pom.yml
@@ -4,12 +4,10 @@ latestFinal:
   releaseDate: 2019-12-12
   releaseNotesVersion: 7
 
-  businessCentralWorkbenchWildFlyWar: https://download.jboss.org/drools/release/7.31.0.Final/business-central-7.31.0.Final-wildfly14.war
   kieExecutionServerZip: https://download.jboss.org/drools/release/7.31.0.Final/kie-server-distribution-7.31.0.Final.zip
 
   engineDocumentationHtmlSingle: https://docs.optaplanner.org/7.31.0.Final/optaplanner-docs/html_single/index.html
   engineDocumentationPdf: https://docs.optaplanner.org/7.31.0.Final/optaplanner-docs/pdf/index.pdf
-  kieWorkbenchDocumentationHtmlSingle: https://docs.optaplanner.org/7.31.0.Final/optaplanner-wb-es-docs/html_single/#_wb.workbench
   kieExecutionServerDocumentationHtmlSingle: https://docs.optaplanner.org/7.31.0.Final/optaplanner-wb-es-docs/html_single/#_ch.kie.server
   optawebEmployeeRosteringDocumentationHtmlSingle: https://docs.optaplanner.org/7.31.0.Final/optaweb-employee-rostering-docs/html_single/index.html
   optawebEmployeeRosteringDocumentationPdf: https://docs.optaplanner.org/7.31.0.Final/optaweb-employee-rostering-docs/pdf/index.pdf
@@ -18,7 +16,6 @@ latestFinal:
   droolsExpertDocumentationHtmlSingle: https://docs.jboss.org/drools/release/7.31.0.Final/drools-docs/html_single/index.html
 
   javadocs: https://docs.optaplanner.org/7.31.0.Final/optaplanner-javadoc/index.html
-  kieWorkbenchReleaseNotes: https://docs.drools.org/7.31.0.Final/drools-docs/html_single/index.html#_wb.releasenotesworkbench.7.31.0.Final
 
 # latest.version can be equal to latestFinal.version
 latest:
@@ -27,24 +24,20 @@ latest:
   releaseDate: 2019-12-12
   releaseNotesVersion: 7
 
-  businessCentralWorkbenchWildFlyWar: https://download.jboss.org/drools/release/7.31.0.Final/business-central-7.31.0.Final-wildfly14.war
   kieExecutionServerZip: https://download.jboss.org/drools/release/7.31.0.Final/kie-server-distribution-7.31.0.Final.zip
 
   engineDocumentationHtmlSingle: https://docs.optaplanner.org/7.31.0.Final/optaplanner-docs/html_single/index.html
 
   javadocs: https://docs.optaplanner.org/7.31.0.Final/optaplanner-javadoc/index.html
-  kieWorkbenchReleaseNotes: https://docs.drools.org/7.31.0.Final/drools-docs/html_single/index.html#_wb.releasenotesworkbench.7.0.0.final
 
 nightly:
   version: 7.32.0-SNAPSHOT
   # The Jenkins public mirror is unreliable because it's stale, so we use JBoss Nexus
   distributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-distribution&v=7.32.0-SNAPSHOT&e=zip
-  kieWorkbenchWildFlyWar: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie&a=business-central&v=7.32.0-SNAPSHOT&e=war&c=wildfly14
   kieExecutionServerJavaEE7: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.32.0-SNAPSHOT&e=war&c=ee7
   kieExecutionServerWebc: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.32.0-SNAPSHOT&e=war&c=webc
 
   engineDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-docs&v=7.32.0-SNAPSHOT&e=zip
-  kieWorkbenchDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-wb-es-guide&v=7.32.0-SNAPSHOT&e=zip
   kieExecutionServerDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-wb-es-guide&v=7.32.0-SNAPSHOT&e=zip
   optwebEmployeeRosteringDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.employeerostering&a=employee-rostering-docs&v=7.32.0-SNAPSHOT&e=zip
   optwebVehicleRoutingDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.vehiclerouting&a=optaweb-vehicle-routing-docs&v=7.32.0-SNAPSHOT&e=zip

--- a/download/download.html.haml
+++ b/download/download.html.haml
@@ -16,8 +16,6 @@ title: Download
   %li(class="active")
     %a(href="#engine" data-toggle="pill") Engine
   %li
-    %a(href="#workbench" data-toggle="pill") Workbench
-  %li
     %a(href="#execution-server" data-toggle="pill") Execution Server
 
 %div(class="tab-content download-tab-content")
@@ -93,13 +91,6 @@ title: Download
 
       This is similar for Ivy and Buildr.
 
-  %div(id="workbench" class="tab-pane fade")
-    :asciidoc
-      * image:download.png[Download] *Download OptaPlanner Workbench #{site.pom.latestFinal.version}*
-      ** #{site.pom.latestFinal.businessCentralWorkbenchWildFlyWar}[WildFly14]
-      ** #{site.pom.latestFinal.kieWorkbenchReleaseNotes}[Release notes #{site.pom.latestFinal.releaseNotesVersion} (general)]
-      ** License: link:../code/license.html[Apache Software License 2.0] - Date: #{site.pom.latestFinal.releaseDate.strftime('%a %-d %B %Y')}
-      * For Red Hat subscription releases https://access.redhat.com/downloads[go to the product download site].
   %div(id="execution-server" class="tab-pane fade")
     :asciidoc
       * image:download.png[Download] *Download OptaPlanner Execution Server #{site.pom.latestFinal.version}*
@@ -131,8 +122,6 @@ title: Download
     %li(class="active")
       %a(href="#engine-nonfinal" data-toggle="pill") Engine
     %li
-      %a(href="#workbench-nonfinal" data-toggle="pill") Workbench
-    %li
       %a(href="#execution-server-nonfinal" data-toggle="pill") Execution Server
 
   %div(class="tab-content download-tab-content")
@@ -153,13 +142,6 @@ title: Download
             <version>#{site.pom.latest.version}</version>
           </dependency>
         ----
-    %div(id="workbench-nonfinal" class="tab-pane fade")
-      :asciidoc
-        * image:download.png[Download] *Download OptaPlanner Workbench #{site.pom.latest.version}*
-          ** #{site.pom.latest.kieWorkbenchWildFlyWar}[WildFly14]
-          ** #{site.pom.latest.kieWorkbenchReleaseNotes}[Release notes #{site.pom.latest.releaseNotesVersion} (general)] -
-          link:releaseNotes/releaseNotes#{site.pom.latest.releaseNotesVersion}.html#_workbench[Release notes #{site.pom.latest.releaseNotesVersion} (OptaPlanner)]
-          ** License: link:../code/license.html[Apache Software License 2.0] - Date: #{site.pom.latestFinal.releaseDate.strftime('%a %-d %B %Y')}
     %div(id="execution-server-nonfinal" class="tab-pane fade")
       :asciidoc
         * image:download.png[Download] *Download OptaPlanner Execution Server #{site.pom.latest.version}*
@@ -177,18 +159,12 @@ title: Download
   %li(class="active")
     %a(href="#engine-nightly" data-toggle="pill") Engine
   %li
-    %a(href="#workbench-nightly" data-toggle="pill") Workbench
-  %li
     %a(href="#execution-server-nightly" data-toggle="pill") Execution Server
 
 %div(class="tab-content download-tab-content")
   %div(id="engine-nightly" class="tab-pane fade in active")
     :asciidoc
       * image:download.png[Download] *#{site.pom.nightly.distributionZip}[Download OptaPlanner Engine #{site.pom.nightly.version}]*
-  %div(id="workbench-nightly" class="tab-pane fade")
-    :asciidoc
-      * image:download.png[Download] *Download OptaPlanner Workbench #{site.pom.nightly.version}*
-      ** #{site.pom.nightly.kieWorkbenchWildFlyWar}[WildFly14]
   %div(id="execution-server-nightly" class="tab-pane fade")
     :asciidoc
       * image:download.png[Download] *Download OptaPlanner Execution Server #{site.pom.nightly.version}*
@@ -203,17 +179,12 @@ title: Download
   %li(class="active")
     %a(href="#engine-older" data-toggle="pill") Engine
   %li
-    %a(href="#workbench-older" data-toggle="pill") Workbench
-  %li
     %a(href="#execution-server-older" data-toggle="pill") Execution Server
 
 %div(class="tab-content download-tab-content")
   %div(id="engine-older" class="tab-pane fade in active")
     :asciidoc
       For older community releases, check https://download.jboss.org/optaplanner/release/[the release archive].
-  %div(id="workbench-older" class="tab-pane fade")
-    :asciidoc
-      For older community releases, check https://download.jboss.org/drools/release/[the release archive].
   %div(id="execution-server-older" class="tab-pane fade")
     :asciidoc
       For older community releases, check https://download.jboss.org/drools/release/[the release archive].

--- a/learn/documentation.html.haml
+++ b/learn/documentation.html.haml
@@ -16,8 +16,6 @@ title: Documentation
   %li(class="active")
     %a(href="#engine" data-toggle="pill") Engine
   %li
-    %a(href="#workbench" data-toggle="pill") Workbench
-  %li
     %a(href="#execution-server" data-toggle="pill") Execution Server
   %li
     %a(href="#optaweb-employee-rostering" data-toggle="pill") OptaWeb Employee Rostering
@@ -36,11 +34,6 @@ title: Documentation
 
         ** Drools Expert reference manual:
         #{site.pom.latestFinal.droolsExpertDocumentationHtmlSingle}[HTML Single]
-
-      * Red Hat subscription documentation: Check https://access.redhat.com/documentation/[the customer portal].
-  %div(id="workbench" class="tab-pane fade")
-    :asciidoc
-      * image:documentation.png[Documentation] *#{site.pom.latestFinal.kieWorkbenchDocumentationHtmlSingle}[OptaPlanner Workbench reference manual #{site.pom.latestFinal.version}]*
 
       * Red Hat subscription documentation: Check https://access.redhat.com/documentation/[the customer portal].
   %div(id="execution-server" class="tab-pane fade")
@@ -73,8 +66,6 @@ title: Documentation
   %li(class="active")
     %a(href="#engine-nightly" data-toggle="pill") Engine
   %li
-    %a(href="#workbench-nightly" data-toggle="pill") Workbench
-  %li
     %a(href="#execution-server-nightly" data-toggle="pill") Execution Server
   %li
     %a(href="#optaweb-employee-rostering-nightly" data-toggle="pill") OptaWeb Employee Rostering
@@ -85,9 +76,6 @@ title: Documentation
   %div(id="engine-nightly" class="tab-pane fade in active")
     :asciidoc
       * image:documentation.png[Documentation] *#{site.pom.nightly.engineDocumentationZip}[OptaPlanner Engine reference manual #{site.pom.nightly.version}]*
-  %div(id="workbench-nightly" class="tab-pane fade")
-    :asciidoc
-      * image:documentation.png[Documentation] *#{site.pom.nightly.kieWorkbenchDocumentationZip}[OptaPlanner Workbench reference manual #{site.pom.nightly.version}]*
   %div(id="execution-server-nightly" class="tab-pane fade")
     :asciidoc
       * image:documentation.png[Documentation] *#{site.pom.nightly.kieExecutionServerDocumentationZip}[OptaPlanner Execution Server reference manual #{site.pom.nightly.version}]*
@@ -106,8 +94,6 @@ title: Documentation
   %li(class="active")
     %a(href="#engine-older" data-toggle="pill") Engine
   %li
-    %a(href="#workbench-older" data-toggle="pill") Workbench
-  %li
     %a(href="#execution-server-older" data-toggle="pill") Execution Server
   %li
     %a(href="#optaweb-employee-rostering-older" data-toggle="pill") OptaWeb Employee Rostering
@@ -116,9 +102,6 @@ title: Documentation
 
 %div(class="tab-content download-tab-content")
   %div(id="engine-older" class="tab-pane fade in active")
-    :asciidoc
-      For older community releases, check https://docs.optaplanner.org/[the documentation archive].
-  %div(id="workbench-older" class="tab-pane fade")
     :asciidoc
       For older community releases, check https://docs.optaplanner.org/[the documentation archive].
   %div(id="execution-server-older" class="tab-pane fade")


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/PLANNER-1721