### PR TITLE
[PLANNER-1811] Add optaweb prefix in employee rostering zip links

### DIFF
--- a/_config/pom.yml
+++ b/_config/pom.yml
@@ -38,10 +38,10 @@ nightly:
   distributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-distribution&v=7.33.0-SNAPSHOT&e=zip
   kieExecutionServerJavaEE7: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.33.0-SNAPSHOT&e=war&c=ee7
   kieExecutionServerWebc: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.33.0-SNAPSHOT&e=war&c=webc
-  optawebEmployeeRosteringDistributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.employeerostering&a=employee-rostering-distribution&v=7.33.0-SNAPSHOT&e=zip
+  optawebEmployeeRosteringDistributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.employeerostering&a=optaweb-employee-rostering-distribution&v=7.33.0-SNAPSHOT&e=zip
   optawebVehicleRoutingDistributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.vehiclerouting&a=optaweb-vehicle-routing-distribution&v=7.33.0-SNAPSHOT&e=zip
 
   engineDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-docs&v=7.33.0-SNAPSHOT&e=zip
   kieExecutionServerDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-wb-es-guide&v=7.33.0-SNAPSHOT&e=zip
-  optwebEmployeeRosteringDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.employeerostering&a=employee-rostering-docs&v=7.33.0-SNAPSHOT&e=zip
+  optwebEmployeeRosteringDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.employeerostering&a=optaweb-employee-rostering-docs&v=7.33.0-SNAPSHOT&e=zip
   optwebVehicleRoutingDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.vehiclerouting&a=optaweb-vehicle-routing-docs&v=7.33.0-SNAPSHOT&e=zip


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/PLANNER-1811

Merge with:
- https://github.com/kiegroup/optaweb-employee-rostering/pull/377
- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1174

Note: The `optawebEmployeeRosteringDistributionZip` link needs to be updated with the new zip file name right before `7.33.0.Final` is released.