### PR TITLE
PLANNER-2187 Use java 11 minimum for OptaPlanner 8

### DIFF
--- a/_partials/downloadJumbotron.html.haml
+++ b/_partials/downloadJumbotron.html.haml
@@ -11,7 +11,7 @@
   %ol
     %li Download the zip and unzip it
     %li
-      On Linux/Mac, run
+      On Linux/macOS, run
       %code examples/runExamples.sh
       %br
       On Windows, run

--- a/download/upgradeRecipe/upgradeRecipe8.adoc
+++ b/download/upgradeRecipe/upgradeRecipe8.adoc
@@ -17,25 +17,25 @@ Any backwards incompatible changes are annotated with a [.label.label-danger.lab
 
 == Backwards incompatible changes to the public API since 7.x
 
-//[.upgrade-recipe-major.upgrade-recipe-public-api]
-//=== Java 11 or higher required
-//
-//If you're using JRE or JDK 8, upgrade to JDK 11 or higher.
-//
-//JDK 11 or higher is still available for _free_ (including security and bug fixes),
-//alongside Oracle's paid subscription.
-//
-//* On linux, get OpenJDK from your linux software repository.
-//For example on Fedora and RHEL:
-//+
-//[source, bash]
-//----
-//sudo dnf install java-11-openjdk-devel
-//----
-//
-//* On Windows and Mac, https://adoptopenjdk.net[download OpenJDK from AdoptOpenJDK].
-//
-//We currently intend to support a minimal version of Java 11 throughout the entire 8.x series.
+[.upgrade-recipe-major.upgrade-recipe-public-api]
+=== Java 11 or higher required
+
+If you're using JRE or JDK 8, upgrade to JDK 11 or higher.
+
+JDK 11 or higher is still available for _free_ (including security and bug fixes),
+alongside Oracle's paid subscription.
+
+* On linux, get OpenJDK from your linux software repository.
+For example on Fedora and RHEL:
++
+[source, bash]
+----
+sudo dnf install java-11-openjdk-devel
+----
+
+* On Windows and Mac, https://adoptopenjdk.net[download OpenJDK from AdoptOpenJDK].
+
+We currently intend to support a minimal version of Java 11 throughout the entire 8.x series.
 
 [.upgrade-recipe-major.upgrade-recipe-public-api]
 === `SolverFactory` and `PlannerBenchmarkFactory` no longer support KIE containers

--- a/download/upgradeRecipe/upgradeRecipe8.adoc
+++ b/download/upgradeRecipe/upgradeRecipe8.adoc
@@ -33,7 +33,7 @@ For example on Fedora and RHEL:
 sudo dnf install java-11-openjdk-devel
 ----
 
-* On Windows and Mac, https://adoptopenjdk.net[download OpenJDK from AdoptOpenJDK].
+* On Windows and macOS, https://adoptopenjdk.net[download OpenJDK from AdoptOpenJDK].
 
 We currently intend to support a minimal version of Java 11 throughout the entire 8.x series.
 

--- a/localized/ja/UserGuide-chapter1.adoc
+++ b/localized/ja/UserGuide-chapter1.adoc
@@ -163,7 +163,7 @@ OptaPlanner は、複数の最適化アルゴリズムを備えており、そ�
 
 {empty}3. +*examples*+ ディレクトリを開き、スクリプトを実行します。
 
-Linux または Mac:
+Linux または macOS:
 
 // [source] //
 ----


### PR DESCRIPTION
JIRA:
https://issues.redhat.com/browse/PLANNER-2187

Relates to:
https://github.com/kiegroup/optaplanner/pull/950
https://github.com/kiegroup/optaplanner-quickstarts/pull/6