### PR TITLE
updated to 7.44.0.Final

### DIFF
--- a/_config/pom.yml
+++ b/_config/pom.yml
@@ -1,47 +1,47 @@
 latestFinal:
-  version: 7.43.1.Final
-  distributionZip: https://download.jboss.org/optaplanner/release/7.43.1.Final/optaplanner-distribution-7.43.1.Final.zip
-  releaseDate: 2020-09-14
+  version: 7.44.0.Final
+  distributionZip: https://download.jboss.org/optaplanner/release/7.44.0.Final/optaplanner-distribution-7.44.0.Final.zip
+  releaseDate: 2020-10-06
   releaseNotesVersion: 7
 
-  kieExecutionServerZip: https://download.jboss.org/drools/release/7.43.1.Final/kie-server-distribution-7.43.1.Final.zip
-  optawebEmployeeRosteringDistributionZip: https://download.jboss.org/optaplanner/release/7.43.1.Final/optaweb-employee-rostering-distribution-7.43.1.Final.zip
-  optawebVehicleRoutingDistributionZip: https://download.jboss.org/optaplanner/release/7.43.1.Final/optaweb-vehicle-routing-distribution-7.43.1.Final.zip
+  kieExecutionServerZip: https://download.jboss.org/drools/release/7.44.0.Final/kie-server-distribution-7.44.0.Final.zip
+  optawebEmployeeRosteringDistributionZip: https://download.jboss.org/optaplanner/release/7.44.0.Final/optaweb-employee-rostering-distribution-7.44.0.Final.zip
+  optawebVehicleRoutingDistributionZip: https://download.jboss.org/optaplanner/release/7.44.0.Final/optaweb-vehicle-routing-distribution-7.44.0.Final.zip
 
-  engineDocumentationHtmlSingle: https://docs.optaplanner.org/7.43.1.Final/optaplanner-docs/html_single/index.html
-  engineDocumentationPdf: https://docs.optaplanner.org/7.43.1.Final/optaplanner-docs/pdf/optaplanner-docs.pdf
-  kieExecutionServerDocumentationHtmlSingle: https://docs.optaplanner.org/7.43.1.Final/optaplanner-wb-es-docs/html_single/#_ch.kie.server
-  optawebEmployeeRosteringDocumentationHtmlSingle: https://docs.optaplanner.org/7.43.1.Final/optaweb-employee-rostering-docs/html_single/index.html
-  optawebEmployeeRosteringDocumentationPdf: https://docs.optaplanner.org/7.43.1.Final/optaweb-employee-rostering-docs/pdf/optaweb-employee-rostering-docs.pdf
-  optawebVehicleRoutingDocumentationHtmlSingle: https://docs.optaplanner.org/7.43.1.Final/optaweb-vehicle-routing-docs/html_single/index.html
-  optawebVehicleRoutingDocumentationPdf: https://docs.optaplanner.org/7.43.1.Final/optaweb-vehicle-routing-docs/pdf/optaweb-vehicle-routing-docs.pdf
-  droolsExpertDocumentationHtmlSingle: https://docs.jboss.org/drools/release/7.43.1.Final/drools-docs/html_single/index.html
+  engineDocumentationHtmlSingle: https://docs.optaplanner.org/7.44.0.Final/optaplanner-docs/html_single/index.html
+  engineDocumentationPdf: https://docs.optaplanner.org/7.44.0.Final/optaplanner-docs/pdf/optaplanner-docs.pdf
+  kieExecutionServerDocumentationHtmlSingle: https://docs.optaplanner.org/7.44.0.Final/optaplanner-wb-es-docs/html_single/#_ch.kie.server
+  optawebEmployeeRosteringDocumentationHtmlSingle: https://docs.optaplanner.org/7.44.0.Final/optaweb-employee-rostering-docs/html_single/index.html
+  optawebEmployeeRosteringDocumentationPdf: https://docs.optaplanner.org/7.44.0.Final/optaweb-employee-rostering-docs/pdf/optaweb-employee-rostering-docs.pdf
+  optawebVehicleRoutingDocumentationHtmlSingle: https://docs.optaplanner.org/7.44.0.Final/optaweb-vehicle-routing-docs/html_single/index.html
+  optawebVehicleRoutingDocumentationPdf: https://docs.optaplanner.org/7.44.0.Final/optaweb-vehicle-routing-docs/pdf/optaweb-vehicle-routing-docs.pdf
+  droolsExpertDocumentationHtmlSingle: https://docs.jboss.org/drools/release/7.44.0.Final/drools-docs/html_single/index.html
 
-  javadocs: https://docs.optaplanner.org/7.43.1.Final/optaplanner-javadoc/index.html
+  javadocs: https://docs.optaplanner.org/7.44.0.Final/optaplanner-javadoc/index.html
 
 # latest.version can be equal to latestFinal.version
 latest:
-  version: 7.43.1.Final
-  distributionZip: https://download.jboss.org/optaplanner/release/7.43.1.Final/optaplanner-distribution-7.43.1.Final.zip
-  releaseDate: 2020-09-14
+  version: 7.44.0.Final
+  distributionZip: https://download.jboss.org/optaplanner/release/7.44.0.Final/optaplanner-distribution-7.44.0.Final.zip
+  releaseDate: 2020-10-06
   releaseNotesVersion: 7
 
-  kieExecutionServerZip: https://download.jboss.org/drools/release/7.43.1.Final/kie-server-distribution-7.43.1.Final.zip
+  kieExecutionServerZip: https://download.jboss.org/drools/release/7.44.0.Final/kie-server-distribution-7.44.0.Final.zip
 
-  engineDocumentationHtmlSingle: https://docs.optaplanner.org/7.43.1.Final/optaplanner-docs/html_single/index.html
+  engineDocumentationHtmlSingle: https://docs.optaplanner.org/7.44.0.Final/optaplanner-docs/html_single/index.html
 
-  javadocs: https://docs.optaplanner.org/7.43.1.Final/optaplanner-javadoc/index.html
+  javadocs: https://docs.optaplanner.org/7.44.0.Final/optaplanner-javadoc/index.html
 
 nightly:
-  version: 7.44.0-SNAPSHOT
+  version: 7.45.0-SNAPSHOT
   # The Jenkins public mirror is unreliable because it's stale, so we use JBoss Nexus
-  distributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-distribution&v=7.44.0-SNAPSHOT&e=zip
-  kieExecutionServerJavaEE7: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.44.0-SNAPSHOT&e=war&c=ee7
-  kieExecutionServerWebc: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.44.0-SNAPSHOT&e=war&c=webc
-  optawebEmployeeRosteringDistributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.employeerostering&a=optaweb-employee-rostering-distribution&v=7.44.0-SNAPSHOT&e=zip
-  optawebVehicleRoutingDistributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.vehiclerouting&a=optaweb-vehicle-routing-distribution&v=7.44.0-SNAPSHOT&e=zip
+  distributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-distribution&v=7.45.0-SNAPSHOT&e=zip
+  kieExecutionServerJavaEE7: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.45.0-SNAPSHOT&e=war&c=ee7
+  kieExecutionServerWebc: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.45.0-SNAPSHOT&e=war&c=webc
+  optawebEmployeeRosteringDistributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.employeerostering&a=optaweb-employee-rostering-distribution&v=7.45.0-SNAPSHOT&e=zip
+  optawebVehicleRoutingDistributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.vehiclerouting&a=optaweb-vehicle-routing-distribution&v=7.45.0-SNAPSHOT&e=zip
 
-  engineDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-docs&v=7.44.0-SNAPSHOT&e=zip
-  kieExecutionServerDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-wb-es-guide&v=7.44.0-SNAPSHOT&e=zip
-  optwebEmployeeRosteringDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.employeerostering&a=optaweb-employee-rostering-docs&v=7.44.0-SNAPSHOT&e=zip
-  optwebVehicleRoutingDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.vehiclerouting&a=optaweb-vehicle-routing-docs&v=7.44.0-SNAPSHOT&e=zip
+  engineDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-docs&v=7.45.0-SNAPSHOT&e=zip
+  kieExecutionServerDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-wb-es-guide&v=7.45.0-SNAPSHOT&e=zip
+  optwebEmployeeRosteringDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.employeerostering&a=optaweb-employee-rostering-docs&v=7.45.0-SNAPSHOT&e=zip
+  optwebVehicleRoutingDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.vehiclerouting&a=optaweb-vehicle-routing-docs&v=7.45.0-SNAPSHOT&e=zip


### PR DESCRIPTION
the links to 
https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.employeerostering&a=optaweb-employee-rostering-distribution&v=7.45.0-SNAPSHOT&e=zip

and 

https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.vehiclerouting&a=optaweb-vehicle-routing-distribution&v=7.45.0-SNAPSHOT&e=zip

are dead somehow - like there is nothing! Please check this.