### PR TITLE
Release OptaPlanner 8.0.0.Beta1

### DIFF
--- a/_config/pom.yml
+++ b/_config/pom.yml
@@ -4,44 +4,36 @@ latestFinal:
   releaseDate: 2020-10-23
   releaseNotesVersion: 7
 
-  kieExecutionServerZip: https://download.jboss.org/drools/release/7.45.0.Final/kie-server-distribution-7.45.0.Final.zip
   optawebEmployeeRosteringDistributionZip: https://download.jboss.org/optaplanner/release/7.45.0.Final/optaweb-employee-rostering-distribution-7.45.0.Final.zip
   optawebVehicleRoutingDistributionZip: https://download.jboss.org/optaplanner/release/7.45.0.Final/optaweb-vehicle-routing-distribution-7.45.0.Final.zip
 
   engineDocumentationHtmlSingle: https://docs.optaplanner.org/7.45.0.Final/optaplanner-docs/html_single/index.html
   engineDocumentationPdf: https://docs.optaplanner.org/7.45.0.Final/optaplanner-docs/pdf/optaplanner-docs.pdf
-  kieExecutionServerDocumentationHtmlSingle: https://docs.optaplanner.org/7.45.0.Final/optaplanner-wb-es-docs/html_single/#_ch.kie.server
   optawebEmployeeRosteringDocumentationHtmlSingle: https://docs.optaplanner.org/7.45.0.Final/optaweb-employee-rostering-docs/html_single/index.html
   optawebEmployeeRosteringDocumentationPdf: https://docs.optaplanner.org/7.45.0.Final/optaweb-employee-rostering-docs/pdf/optaweb-employee-rostering-docs.pdf
   optawebVehicleRoutingDocumentationHtmlSingle: https://docs.optaplanner.org/7.45.0.Final/optaweb-vehicle-routing-docs/html_single/index.html
   optawebVehicleRoutingDocumentationPdf: https://docs.optaplanner.org/7.45.0.Final/optaweb-vehicle-routing-docs/pdf/optaweb-vehicle-routing-docs.pdf
-  droolsExpertDocumentationHtmlSingle: https://docs.jboss.org/drools/release/7.45.0.Final/drools-docs/html_single/index.html
 
   javadocs: https://docs.optaplanner.org/7.45.0.Final/optaplanner-javadoc/index.html
 
 # latest.version can be equal to latestFinal.version
 latest:
-  version: 7.45.0.Final
-  distributionZip: https://download.jboss.org/optaplanner/release/7.45.0.Final/optaplanner-distribution-7.45.0.Final.zip
-  releaseDate: 2020-10-23
-  releaseNotesVersion: 7
+  version: 8.0.0.Beta1
+  distributionZip: https://download.jboss.org/optaplanner/release/8.0.0.Beta1/optaplanner-distribution-8.0.0.Beta1.zip
+  releaseDate: 2020-11-02
+  releaseNotesVersion: 8
 
-  kieExecutionServerZip: https://download.jboss.org/drools/release/7.45.0.Final/kie-server-distribution-7.45.0.Final.zip
+  engineDocumentationHtmlSingle: https://docs.optaplanner.org/8.0.0.Beta1/optaplanner-docs/html_single/index.html
 
-  engineDocumentationHtmlSingle: https://docs.optaplanner.org/7.45.0.Final/optaplanner-docs/html_single/index.html
-
-  javadocs: https://docs.optaplanner.org/7.45.0.Final/optaplanner-javadoc/index.html
+  javadocs: https://docs.optaplanner.org/8.0.0.Beta1/optaplanner-javadoc/index.html
 
 nightly:
-  version: 7.46.0-SNAPSHOT
+  version: 8.0.0-SNAPSHOT
   # The Jenkins public mirror is unreliable because it's stale, so we use JBoss Nexus
-  distributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-distribution&v=7.46.0-SNAPSHOT&e=zip
-  kieExecutionServerJavaEE7: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.46.0-SNAPSHOT&e=war&c=ee7
-  kieExecutionServerWebc: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.kie.server&a=kie-server&v=7.46.0-SNAPSHOT&e=war&c=webc
+  distributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-distribution&v=8.0.0-SNAPSHOT&e=zip
   optawebEmployeeRosteringDistributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.employeerostering&a=optaweb-employee-rostering-distribution&v=7.46.0-SNAPSHOT&e=zip
   optawebVehicleRoutingDistributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.vehiclerouting&a=optaweb-vehicle-routing-distribution&v=7.46.0-SNAPSHOT&e=zip
 
-  engineDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-docs&v=7.46.0-SNAPSHOT&e=zip
-  kieExecutionServerDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-wb-es-guide&v=7.46.0-SNAPSHOT&e=zip
+  engineDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-docs&v=8.0.0-SNAPSHOT&e=zip
   optwebEmployeeRosteringDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.employeerostering&a=optaweb-employee-rostering-docs&v=7.46.0-SNAPSHOT&e=zip
   optwebVehicleRoutingDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.vehiclerouting&a=optaweb-vehicle-routing-docs&v=7.46.0-SNAPSHOT&e=zip

--- a/download/download.html.haml
+++ b/download/download.html.haml
@@ -95,12 +95,6 @@ title: Download
 
       This is similar for Ivy and Buildr.
 
-  %div(id="execution-server" class="tab-pane fade")
-    :asciidoc
-      * image:download.png[Download] *Download OptaPlanner Execution Server #{site.pom.latestFinal.version}*
-      ** #{site.pom.latestFinal.kieExecutionServerZip}[Any application server]
-      ** License: link:../code/license.html[Apache License 2.0] - Date: #{site.pom.latestFinal.releaseDate.strftime('%a %-d %B %Y')}
-      * For Red Hat subscription releases https://access.redhat.com/downloads[go to the product download site].
   %div(id="optaweb-employee-rostering" class="tab-pane fade")
     :asciidoc
       * image:download.png[Download] *#{site.pom.latestFinal.optawebEmployeeRosteringDistributionZip}[Download OptaWeb Employee Rostering #{site.pom.latestFinal.version}]*
@@ -156,12 +150,6 @@ title: Download
             <version>#{site.pom.latest.version}</version>
           </dependency>
         ----
-    %div(id="execution-server-nonfinal" class="tab-pane fade")
-      :asciidoc
-        * image:download.png[Download] *Download OptaPlanner Execution Server #{site.pom.latest.version}*
-        ** #{site.pom.latest.kieExecutionServerZip}[Any application server]
-        ** link:releaseNotes/releaseNotes#{site.pom.latest.releaseNotesVersion}.html#_execution_server[Release notes #{site.pom.latest.releaseNotesVersion} (OptaPlanner)]
-        ** License: link:../code/license.html[Apache License 2.0] - Date: #{site.pom.latestFinal.releaseDate.strftime('%a %-d %B %Y')}
 
 :asciidoc
   [[NightlySnapshots]]
@@ -183,11 +171,6 @@ title: Download
   %div(id="engine-nightly" class="tab-pane fade in active")
     :asciidoc
       * image:download.png[Download] *#{site.pom.nightly.distributionZip}[Download OptaPlanner Engine #{site.pom.nightly.version}]*
-  %div(id="execution-server-nightly" class="tab-pane fade")
-    :asciidoc
-      * image:download.png[Download] *Download OptaPlanner Execution Server #{site.pom.nightly.version}*
-      ** #{site.pom.nightly.kieExecutionServerJavaEE7}[JavaEE 7] -
-      #{site.pom.nightly.kieExecutionServerWebc}[Web (Servlet) container]
   %div(id="optaweb-employee-rostering-nightly" class="tab-pane fade")
     :asciidoc
       * image:download.png[Download] *#{site.pom.nightly.optawebEmployeeRosteringDistributionZip}[Download OptaWeb Employee Rostering #{site.pom.nightly.version}]*

--- a/learn/documentation.html.haml
+++ b/learn/documentation.html.haml
@@ -32,14 +32,6 @@ title: Documentation
         ** Javadocs:
         #{site.pom.latestFinal.javadocs}[HTML]
 
-        ** Drools Expert reference manual:
-        #{site.pom.latestFinal.droolsExpertDocumentationHtmlSingle}[HTML Single]
-
-      * Red Hat subscription documentation: Check https://access.redhat.com/documentation/[the customer portal].
-  %div(id="execution-server" class="tab-pane fade")
-    :asciidoc
-      * image:documentation.png[Documentation] *#{site.pom.latestFinal.kieExecutionServerDocumentationHtmlSingle}[OptaPlanner Execution Server reference manual #{site.pom.latestFinal.version}]*
-
       * Red Hat subscription documentation: Check https://access.redhat.com/documentation/[the customer portal].
   %div(id="optaweb-employee-rostering" class="tab-pane fade")
     :asciidoc
@@ -76,9 +68,6 @@ title: Documentation
   %div(id="engine-nightly" class="tab-pane fade in active")
     :asciidoc
       * image:documentation.png[Documentation] *#{site.pom.nightly.engineDocumentationZip}[OptaPlanner Engine reference manual #{site.pom.nightly.version}]*
-  %div(id="execution-server-nightly" class="tab-pane fade")
-    :asciidoc
-      * image:documentation.png[Documentation] *#{site.pom.nightly.kieExecutionServerDocumentationZip}[OptaPlanner Execution Server reference manual #{site.pom.nightly.version}]*
   %div(id="optaweb-employee-rostering-nightly" class="tab-pane fade")
     :asciidoc
       * image:documentation.png[Documentation] *#{site.pom.nightly.optwebEmployeeRosteringDocumentationZip}[OptaWeb Employee Rostering reference manual #{site.pom.nightly.version}]*

--- a/xsd/benchmark/benchmark-8.xsd
+++ b/xsd/benchmark/benchmark-8.xsd
@@ -1,10 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://www.optaplanner.org/xsd/benchmark" elementFormDefault="qualified" targetNamespace="https://www.optaplanner.org/xsd/benchmark" version="1.0">
-
-  
-
   <xs:element name="plannerBenchmark" type="tns:plannerBenchmarkConfig"/>
-
   <xs:complexType name="plannerBenchmarkConfig">
     <xs:sequence>
       <xs:element minOccurs="0" name="name" type="xs:string"/>
@@ -22,7 +18,6 @@
       <xs:element maxOccurs="unbounded" minOccurs="0" name="solverBenchmark" type="tns:solverBenchmarkConfig"/>
     </xs:sequence>
   </xs:complexType>
-
   <xs:complexType name="benchmarkReportConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -35,7 +30,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="solverBenchmarkConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -48,7 +42,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="problemBenchmarksConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -63,13 +56,11 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="solverBenchmarkBluePrintConfig">
     <xs:sequence>
       <xs:element minOccurs="0" name="solverBenchmarkBluePrintType" type="tns:solverBenchmarkBluePrintType"/>
     </xs:sequence>
   </xs:complexType>
-
   <xs:simpleType name="solverRankingType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="TOTAL_SCORE"/>
@@ -77,7 +68,6 @@
       <xs:enumeration value="TOTAL_RANKING"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="problemStatisticType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="BEST_SCORE"/>
@@ -88,7 +78,6 @@
       <xs:enumeration value="MEMORY_USE"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="singleStatisticType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="CONSTRAINT_MATCH_TOTAL_BEST_SCORE"/>
@@ -97,7 +86,6 @@
       <xs:enumeration value="PICKED_MOVE_TYPE_STEP_SCORE_DIFF"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="solverBenchmarkBluePrintType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="CONSTRUCTION_HEURISTIC_WITH_AND_WITHOUT_LOCAL_SEARCH"/>
@@ -106,14 +94,9 @@
       <xs:enumeration value="EVERY_CONSTRUCTION_HEURISTIC_TYPE_WITH_EVERY_LOCAL_SEARCH_TYPE"/>
     </xs:restriction>
   </xs:simpleType>
-
-
-  
-
   <xs:complexType abstract="true" name="abstractConfig">
     <xs:sequence/>
   </xs:complexType>
-
   <xs:complexType name="solverConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -142,7 +125,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="scoreDirectorFactoryConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -163,19 +145,16 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="jaxbAdaptedMap">
     <xs:sequence>
       <xs:element maxOccurs="unbounded" minOccurs="0" name="property" type="tns:jaxbAdaptedMapEntry"/>
     </xs:sequence>
   </xs:complexType>
-
   <xs:complexType name="jaxbAdaptedMapEntry">
     <xs:sequence/>
     <xs:attribute name="name" type="xs:string"/>
     <xs:attribute name="value" type="xs:string"/>
   </xs:complexType>
-
   <xs:complexType name="terminationConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -205,7 +184,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="constructionHeuristicPhaseConfig">
     <xs:complexContent>
       <xs:extension base="tns:phaseConfig">
@@ -236,7 +214,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType abstract="true" name="phaseConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -246,7 +223,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="queuedEntityPlacerConfig">
     <xs:complexContent>
       <xs:extension base="tns:entityPlacerConfig">
@@ -269,7 +245,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType abstract="true" name="entityPlacerConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -277,7 +252,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="entitySelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:selectorConfig">
@@ -300,7 +274,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType abstract="true" name="selectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -308,7 +281,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="nearbySelectionConfig">
     <xs:complexContent>
       <xs:extension base="tns:selectorConfig">
@@ -328,7 +300,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="cartesianProductMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -351,7 +322,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType abstract="true" name="moveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:selectorConfig">
@@ -370,7 +340,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="changeMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -381,7 +350,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="valueSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:selectorConfig">
@@ -405,7 +373,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="unionMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -428,7 +395,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="moveIteratorFactoryConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -439,7 +405,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="moveListFactoryConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -450,7 +415,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="pillarChangeMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractPillarMoveSelectorConfig">
@@ -460,7 +424,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType abstract="true" name="abstractPillarMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -472,7 +435,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="pillarSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:selectorConfig">
@@ -484,7 +446,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="pillarSwapMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractPillarMoveSelectorConfig">
@@ -501,7 +462,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="subChainChangeMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -514,7 +474,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="subChainSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:selectorConfig">
@@ -526,7 +485,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="subChainSwapMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -539,7 +497,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="swapMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -557,7 +514,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="tailChainSwapMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -568,7 +524,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="queuedValuePlacerConfig">
     <xs:complexContent>
       <xs:extension base="tns:entityPlacerConfig">
@@ -592,7 +547,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="pooledEntityPlacerConfig">
     <xs:complexContent>
       <xs:extension base="tns:entityPlacerConfig">
@@ -614,7 +568,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="constructionHeuristicForagerConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -624,7 +577,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="customPhaseConfig">
     <xs:complexContent>
       <xs:extension base="tns:phaseConfig">
@@ -635,7 +587,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="exhaustiveSearchPhaseConfig">
     <xs:complexContent>
       <xs:extension base="tns:phaseConfig">
@@ -662,7 +613,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="localSearchPhaseConfig">
     <xs:complexContent>
       <xs:extension base="tns:phaseConfig">
@@ -687,7 +637,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="localSearchAcceptorConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -715,7 +664,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="localSearchForagerConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -728,7 +676,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="noChangePhaseConfig">
     <xs:complexContent>
       <xs:extension base="tns:phaseConfig">
@@ -736,7 +683,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="partitionedSearchPhaseConfig">
     <xs:complexContent>
       <xs:extension base="tns:phaseConfig">
@@ -756,7 +702,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:simpleType name="environmentMode">
     <xs:restriction base="xs:string">
       <xs:enumeration value="FULL_ASSERT"/>
@@ -766,7 +711,6 @@
       <xs:enumeration value="NON_REPRODUCIBLE"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="randomType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="JDK"/>
@@ -779,21 +723,18 @@
       <xs:enumeration value="WELL44497B"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="constraintStreamImplType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="BAVET"/>
       <xs:enumeration value="DROOLS"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="terminationCompositionStyle">
     <xs:restriction base="xs:string">
       <xs:enumeration value="AND"/>
       <xs:enumeration value="OR"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="constructionHeuristicType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="FIRST_FIT"/>
@@ -808,7 +749,6 @@
       <xs:enumeration value="ALLOCATE_FROM_POOL"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="entitySorterManner">
     <xs:restriction base="xs:string">
       <xs:enumeration value="NONE"/>
@@ -816,7 +756,6 @@
       <xs:enumeration value="DECREASING_DIFFICULTY_IF_AVAILABLE"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="valueSorterManner">
     <xs:restriction base="xs:string">
       <xs:enumeration value="NONE"/>
@@ -826,7 +765,6 @@
       <xs:enumeration value="DECREASING_STRENGTH_IF_AVAILABLE"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="selectionCacheType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="JUST_IN_TIME"/>
@@ -835,7 +773,6 @@
       <xs:enumeration value="SOLVER"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="selectionOrder">
     <xs:restriction base="xs:string">
       <xs:enumeration value="INHERIT"/>
@@ -846,7 +783,6 @@
       <xs:enumeration value="PROBABILISTIC"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="nearbySelectionDistributionType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="BLOCK_DISTRIBUTION"/>
@@ -855,14 +791,12 @@
       <xs:enumeration value="BETA_DISTRIBUTION"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="selectionSorterOrder">
     <xs:restriction base="xs:string">
       <xs:enumeration value="ASCENDING"/>
       <xs:enumeration value="DESCENDING"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="subPillarType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="NONE"/>
@@ -870,7 +804,6 @@
       <xs:enumeration value="ALL"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="constructionHeuristicPickEarlyType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="NEVER"/>
@@ -879,14 +812,12 @@
       <xs:enumeration value="FIRST_FEASIBLE_SCORE_OR_NON_DETERIORATING_HARD"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="exhaustiveSearchType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="BRUTE_FORCE"/>
       <xs:enumeration value="BRANCH_AND_BOUND"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="nodeExplorationType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="ORIGINAL_ORDER"/>
@@ -896,7 +827,6 @@
       <xs:enumeration value="OPTIMISTIC_BOUND_FIRST"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="localSearchType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="HILL_CLIMBING"/>
@@ -907,7 +837,6 @@
       <xs:enumeration value="VARIABLE_NEIGHBORHOOD_DESCENT"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="acceptorType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="HILL_CLIMBING"/>
@@ -921,7 +850,6 @@
       <xs:enumeration value="STEP_COUNTING_HILL_CLIMBING"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="stepCountingHillClimbingType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="SELECTED_MOVE"/>
@@ -931,7 +859,6 @@
       <xs:enumeration value="IMPROVING_STEP"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="localSearchPickEarlyType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="NEVER"/>
@@ -939,7 +866,6 @@
       <xs:enumeration value="FIRST_LAST_STEP_SCORE_IMPROVING"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="finalistPodiumType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="HIGHEST_SCORE"/>

--- a/xsd/solver/solver-8.xsd
+++ b/xsd/solver/solver-8.xsd
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:tns="https://www.optaplanner.org/xsd/solver" elementFormDefault="qualified" targetNamespace="https://www.optaplanner.org/xsd/solver" version="1.0">
-
   <xs:element name="solver" type="tns:solverConfig"/>
-
   <xs:complexType name="solverConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -31,11 +29,9 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType abstract="true" name="abstractConfig">
     <xs:sequence/>
   </xs:complexType>
-
   <xs:complexType name="scoreDirectorFactoryConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -56,19 +52,16 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="jaxbAdaptedMap">
     <xs:sequence>
       <xs:element maxOccurs="unbounded" minOccurs="0" name="property" type="tns:jaxbAdaptedMapEntry"/>
     </xs:sequence>
   </xs:complexType>
-
   <xs:complexType name="jaxbAdaptedMapEntry">
     <xs:sequence/>
     <xs:attribute name="name" type="xs:string"/>
     <xs:attribute name="value" type="xs:string"/>
   </xs:complexType>
-
   <xs:complexType name="terminationConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -98,7 +91,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="constructionHeuristicPhaseConfig">
     <xs:complexContent>
       <xs:extension base="tns:phaseConfig">
@@ -129,7 +121,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType abstract="true" name="phaseConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -139,7 +130,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="queuedEntityPlacerConfig">
     <xs:complexContent>
       <xs:extension base="tns:entityPlacerConfig">
@@ -162,7 +152,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType abstract="true" name="entityPlacerConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -170,7 +159,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="entitySelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:selectorConfig">
@@ -193,7 +181,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType abstract="true" name="selectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -201,7 +188,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="nearbySelectionConfig">
     <xs:complexContent>
       <xs:extension base="tns:selectorConfig">
@@ -221,7 +207,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="cartesianProductMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -244,7 +229,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType abstract="true" name="moveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:selectorConfig">
@@ -263,7 +247,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="changeMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -274,7 +257,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="valueSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:selectorConfig">
@@ -298,7 +280,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="unionMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -321,7 +302,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="moveIteratorFactoryConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -332,7 +312,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="moveListFactoryConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -343,7 +322,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="pillarChangeMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractPillarMoveSelectorConfig">
@@ -353,7 +331,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType abstract="true" name="abstractPillarMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -365,7 +342,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="pillarSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:selectorConfig">
@@ -377,7 +353,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="pillarSwapMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractPillarMoveSelectorConfig">
@@ -394,7 +369,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="subChainChangeMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -407,7 +381,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="subChainSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:selectorConfig">
@@ -419,7 +392,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="subChainSwapMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -432,7 +404,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="swapMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -450,7 +421,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="tailChainSwapMoveSelectorConfig">
     <xs:complexContent>
       <xs:extension base="tns:moveSelectorConfig">
@@ -461,7 +431,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="queuedValuePlacerConfig">
     <xs:complexContent>
       <xs:extension base="tns:entityPlacerConfig">
@@ -485,7 +454,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="pooledEntityPlacerConfig">
     <xs:complexContent>
       <xs:extension base="tns:entityPlacerConfig">
@@ -507,7 +475,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="constructionHeuristicForagerConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -517,7 +484,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="customPhaseConfig">
     <xs:complexContent>
       <xs:extension base="tns:phaseConfig">
@@ -528,7 +494,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="exhaustiveSearchPhaseConfig">
     <xs:complexContent>
       <xs:extension base="tns:phaseConfig">
@@ -555,7 +520,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="localSearchPhaseConfig">
     <xs:complexContent>
       <xs:extension base="tns:phaseConfig">
@@ -580,7 +544,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="localSearchAcceptorConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -608,7 +571,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="localSearchForagerConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -621,7 +583,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="noChangePhaseConfig">
     <xs:complexContent>
       <xs:extension base="tns:phaseConfig">
@@ -629,7 +590,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="partitionedSearchPhaseConfig">
     <xs:complexContent>
       <xs:extension base="tns:phaseConfig">
@@ -649,7 +609,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:complexType name="solverManagerConfig">
     <xs:complexContent>
       <xs:extension base="tns:abstractConfig">
@@ -660,7 +619,6 @@
       </xs:extension>
     </xs:complexContent>
   </xs:complexType>
-
   <xs:simpleType name="environmentMode">
     <xs:restriction base="xs:string">
       <xs:enumeration value="FULL_ASSERT"/>
@@ -670,7 +628,6 @@
       <xs:enumeration value="NON_REPRODUCIBLE"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="randomType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="JDK"/>
@@ -683,21 +640,18 @@
       <xs:enumeration value="WELL44497B"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="constraintStreamImplType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="BAVET"/>
       <xs:enumeration value="DROOLS"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="terminationCompositionStyle">
     <xs:restriction base="xs:string">
       <xs:enumeration value="AND"/>
       <xs:enumeration value="OR"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="constructionHeuristicType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="FIRST_FIT"/>
@@ -712,7 +666,6 @@
       <xs:enumeration value="ALLOCATE_FROM_POOL"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="entitySorterManner">
     <xs:restriction base="xs:string">
       <xs:enumeration value="NONE"/>
@@ -720,7 +673,6 @@
       <xs:enumeration value="DECREASING_DIFFICULTY_IF_AVAILABLE"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="valueSorterManner">
     <xs:restriction base="xs:string">
       <xs:enumeration value="NONE"/>
@@ -730,7 +682,6 @@
       <xs:enumeration value="DECREASING_STRENGTH_IF_AVAILABLE"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="selectionCacheType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="JUST_IN_TIME"/>
@@ -739,7 +690,6 @@
       <xs:enumeration value="SOLVER"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="selectionOrder">
     <xs:restriction base="xs:string">
       <xs:enumeration value="INHERIT"/>
@@ -750,7 +700,6 @@
       <xs:enumeration value="PROBABILISTIC"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="nearbySelectionDistributionType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="BLOCK_DISTRIBUTION"/>
@@ -759,14 +708,12 @@
       <xs:enumeration value="BETA_DISTRIBUTION"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="selectionSorterOrder">
     <xs:restriction base="xs:string">
       <xs:enumeration value="ASCENDING"/>
       <xs:enumeration value="DESCENDING"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="subPillarType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="NONE"/>
@@ -774,7 +721,6 @@
       <xs:enumeration value="ALL"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="constructionHeuristicPickEarlyType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="NEVER"/>
@@ -783,14 +729,12 @@
       <xs:enumeration value="FIRST_FEASIBLE_SCORE_OR_NON_DETERIORATING_HARD"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="exhaustiveSearchType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="BRUTE_FORCE"/>
       <xs:enumeration value="BRANCH_AND_BOUND"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="nodeExplorationType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="ORIGINAL_ORDER"/>
@@ -800,7 +744,6 @@
       <xs:enumeration value="OPTIMISTIC_BOUND_FIRST"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="localSearchType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="HILL_CLIMBING"/>
@@ -811,7 +754,6 @@
       <xs:enumeration value="VARIABLE_NEIGHBORHOOD_DESCENT"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="acceptorType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="HILL_CLIMBING"/>
@@ -825,7 +767,6 @@
       <xs:enumeration value="STEP_COUNTING_HILL_CLIMBING"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="stepCountingHillClimbingType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="SELECTED_MOVE"/>
@@ -835,7 +776,6 @@
       <xs:enumeration value="IMPROVING_STEP"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="localSearchPickEarlyType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="NEVER"/>
@@ -843,7 +783,6 @@
       <xs:enumeration value="FIRST_LAST_STEP_SCORE_IMPROVING"/>
     </xs:restriction>
   </xs:simpleType>
-
   <xs:simpleType name="finalistPodiumType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="HIGHEST_SCORE"/>


### PR DESCRIPTION
- removes links to KIE server and Drools
- updates OptaPlanner links to match the released 8.0.0.Beta1
- updates the XSDs
- optawebs stay on 7.45.0.Final so far

@mbiarnes would you please stop updating the optaplanner-website during the 7.x releases from now? The website will point to 8.x artifacts when we merge this PR.