### PR TITLE
Remove the empty Exec server sections

### DIFF
--- a/download/download.html.haml
+++ b/download/download.html.haml
@@ -16,8 +16,6 @@ title: Download
   %li(class="active")
     %a(href="#engine" data-toggle="pill") Engine
   %li
-    %a(href="#execution-server" data-toggle="pill") Execution Server
-  %li
     %a(href="#optaweb-employee-rostering" data-toggle="pill") OptaWeb Employee Rostering
   %li
     %a(href="#optaweb-vehicle-routing" data-toggle="pill") OptaWeb Vehicle Routing
@@ -129,8 +127,6 @@ title: Download
   %ul(class="nav nav-tabs download-nav-tabs")
     %li(class="active")
       %a(href="#engine-nonfinal" data-toggle="pill") Engine
-    %li
-      %a(href="#execution-server-nonfinal" data-toggle="pill") Execution Server
 
   %div(class="tab-content download-tab-content")
     %div(id="engine-nonfinal" class="tab-pane fade in active")
@@ -161,8 +157,6 @@ title: Download
   %li(class="active")
     %a(href="#engine-nightly" data-toggle="pill") Engine
   %li
-    %a(href="#execution-server-nightly" data-toggle="pill") Execution Server
-  %li
     %a(href="#optaweb-employee-rostering-nightly" data-toggle="pill") OptaWeb Employee Rostering
   %li
     %a(href="#optaweb-vehicle-routing-nightly" data-toggle="pill") OptaWeb Vehicle Routing
@@ -186,8 +180,6 @@ title: Download
   %li(class="active")
     %a(href="#engine-older" data-toggle="pill") Engine
   %li
-    %a(href="#execution-server-older" data-toggle="pill") Execution Server
-  %li
     %a(href="#optaweb-employee-rostering-older" data-toggle="pill") OptaWeb Employee Rostering
   %li
     %a(href="#optaweb-vehicle-routing-older" data-toggle="pill") OptaWeb Vehicle Routing
@@ -196,9 +188,6 @@ title: Download
   %div(id="engine-older" class="tab-pane fade in active")
     :asciidoc
       For older community releases, check https://download.jboss.org/optaplanner/release/[the release archive].
-  %div(id="execution-server-older" class="tab-pane fade")
-    :asciidoc
-      For older community releases, check https://download.jboss.org/drools/release/[the release archive].
   %div(id="optaweb-employee-rostering-older" class="tab-pane fade")
     :asciidoc
       For older community releases, check https://download.jboss.org/optaplanner/release/[the release archive].


### PR DESCRIPTION
I noticed the sections where used to be the Exec server on the Downloads page were still visible. This PR removes them completely.