### PR TITLE
Rsync test

### DIFF
--- a/build/rsync_website.sh
+++ b/build/rsync_website.sh
@@ -4,18 +4,12 @@
 #   You can't execute this script locally since keys, stored in Jenkins, are needed
 #   1. you need to store the id_rsa and known_host file on your local
 #   (for these pwd ask mbiarnes or geoffrey)
-#   2. create a optaplanner directory underneath $HOME/.ssh to store the keys ($HOME/.ssh/optaplanner)
-#   3. create a config file in your $HOME/.ssh directory ($HOME/.ssh/config) with
-#   this configuration:
-#
-#         Host optaplanner
-#            User optaplanner
-#            IdentityFile ~.ssh/optaplanner
-#
+#   2. create a optaplanner directory underneath $HOME/.ssh to store the needed keys ($HOME/.ssh/optaplanner)
+#   3. copy known_hosts and id_rsa (the same as on Jenkins) to $HOME/.ssh/optaplanner
 #   Then you should use:
 #   rsync --dry-run -Pavqr -e "ssh -i $HOME/.ssh/optaplanner/id_rsa" --protocol=28 --delete-after target/website/* optaplanner@filemgmt.jboss.org:www_htdocs/optaplanner
 #   the --dry-run is for testing so you can see if anything is missing. The files are not synced! If you want to execute a "real" rsync please remove --dry-run
 #
 #############################################################################################################################################################################
 
-rsync --dry-run -Pqr --protocol=28 --delete-after target/website/* optaplanner@filemgmt.jboss.org:www_htdocs/optaplanner
+rsync -Pavqr -e "ssh -i $WORKSPACE/optaplanner-website/.ssh/optaplanner/id_rsa" --protocol=28 --delete-after target/website/* optaplanner@filemgmt.jboss.org:www_htdocs/optaplanner

--- a/build/rsync_website.sh
+++ b/build/rsync_website.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#############################################################################################################################################################################
+#
+#   You can't execute this script locally since keys, stored in Jenkins, are needed
+#   1. you need to store the id_rsa and known_host file on your local
+#   (for these pwd ask mbiarnes or geoffrey)
+#   2. create a optaplanner directory underneath $HOME/.ssh to store the keys ($HOME/.ssh/optaplanner)
+#   3. create a config file in your $HOME/.ssh directory ($HOME/.ssh/config) with
+#   this configuration:
+#
+#         Host optaplanner
+#            User optaplanner
+#            IdentityFile ~.ssh/optaplanner
+#
+#   Then you should use:
+#   rsync --dry-run -Pavqr -e "ssh -i $HOME/.ssh/optaplanner/id_rsa" --protocol=28 --delete-after target/website/* optaplanner@filemgmt.jboss.org:www_htdocs/optaplanner
+#   the --dry-run is for testing so you can see if anything is missing. The files are not synced! If you want to execute a "real" rsync please remove --dry-run
+#
+#############################################################################################################################################################################
+
+rsync --dry-run -Pqr --protocol=28 --delete-after target/website/* optaplanner@filemgmt.jboss.org:www_htdocs/optaplanner


### PR DESCRIPTION
@ge0ffrey Here is the new script that should be executed when optaplanner-webiste should be updated.
There is a Jenkins job [optaplanner_web_publishing_bake](https://eng-jenkins-csb-business-automation.apps.ocp4.prod.psi.redhat.com/job/KIE/job/master/job/webs/job/optaplanner_web_publishing_bake/) which has to run manually. Once the decision was taken that it behaves properly we should change the jobs so it works with web-hooks, so they decide when this job runs and can change the name to `optaplanner_web_publishing`.