### PR TITLE
Simplify the jumbotron callouts + add button for quickstarts repo

### DIFF
--- a/templates/macros.ftl
+++ b/templates/macros.ftl
@@ -256,38 +256,41 @@
 
 <#macro downloadJumbotron>
     <div class="jumbotron" style="padding: 10px; margin-bottom: 20px;">
-        <div class="text-center"><a class="btn btn-lg btn-success versionedButton" href="${pom.latestFinal.distributionZip}"><img alt="Download" src="${content.rootpath}download/download.png">
+        <div class="text-center" style="margin-bottom: 10px;"><a class="btn btn-lg btn-success versionedButton" href="${pom.latestFinal.distributionZip}"><img alt="Download" src="${content.rootpath}download/download.png">
             <div>
-                <span>Download OptaPlanner</span><br/>
-                <span class="small">${pom.latestFinal.version}</span>
+                <span>Try OptaPlanner</span><br/>
+                <span class="small">Download ${pom.latestFinal.version}</span>
             </div>
         </a></div>
-        <h4>Try the examples now:</h4>
         <ol>
-            <li>Download the zip and unzip it</li>
+            <li>Download the zip and unzip it.</li>
             <li>
-                On Linux/macOS, run <code>examples/runExamples.sh</code><br/>
-                On Windows, run <code>examples/runExamples.bat</code>
+                Run <code>examples/runExamples.sh</code> (Linux/macOS).<br/>
+                Or run <code>examples/runExamples.bat</code> (Windows).
             </li>
         </ol>
-        <div class="small">
-            Requires <a href="https://www.java.com">Java™</a> to run.
+        <div class="text-center">
+            <div class="small">
+                Requires <a href="https://adoptopenjdk.net">Java™</a> to run.
+            </div>
         </div>
     </div>
 </#macro>
 
 <#macro documentationJumbotron>
     <div class="jumbotron" style="padding: 10px; margin-bottom: 20px;">
-        <div class="text-center"><a class="btn btn-lg btn-primary versionedButton" href="${pom.latestFinal.engineDocumentationHtmlSingle}"><img alt="Documentation" src="${content.rootpath}learn/documentation.png">
+        <div class="text-center" style="margin-bottom: 10px;"><a class="btn btn-lg btn-primary versionedButton" href="${pom.latestFinal.engineDocumentationHtmlSingle}#quickStart"><img alt="Documentation" src="${content.rootpath}learn/documentation.png">
             <div>
-                <span>Read documentation</span><br/>
-                <span class="small">${pom.latestFinal.version}</span>
+                <span>Get started</span><br/>
+                <span class="small">User guide ${pom.latestFinal.version}</span>
             </div>
         </a></div>
-        <p style="margin-top: 10px; margin-bottom: 0;">
-            Read a <a href="${pom.latestFinal.engineDocumentationHtmlSingle}#quickStart">Quick Start</a> guide<br/>
-            or git clone <a href="https://github.com/kiegroup/optaplanner-quickstarts">optaplanner-quickstarts</a>.
-        </p>
+        <div class="text-center">
+            <a href="https://github.com/kiegroup/optaplanner-quickstarts">
+                <img alt="GitHub" src="${content.rootpath}headerFooter/gitHubLogo.png">
+                <span>Clone the Quickstarts code.</span>
+            </a>
+        </div>
     </div>
 </#macro>
 


### PR DESCRIPTION
This is just a step along the way.

BEFORE

![image](https://user-images.githubusercontent.com/176880/128321771-113f03b0-fb4f-4130-923d-4034d5492184.png)

AFTER

![image](https://user-images.githubusercontent.com/176880/128321724-ce9936e8-e398-4633-8018-e3d39148b1a8.png)

The blue button now directly links to chapter 2 (quick start tutorials) in the user guide.
After the Antora work, that button can be adjusted further (see Karina's doc).
