### PR TITLE
Add quarkus tag to Workflow blog post

### DIFF
--- a/content/blog/2020/05/05/WorkflowProcessesWithAIScheduling.adoc
+++ b/content/blog/2020/05/05/WorkflowProcessesWithAIScheduling.adoc
@@ -3,7 +3,7 @@ Christopher-Chianelli
 2020-05-05
 :page-interpolate: true
 :jbake-type: post
-:jbake-tags: use case
+:jbake-tags: use case, quarkus
 :jbake-social_media_share_image: FinalBPMN.png
 
 A BPMN diagram models a Business Process. When the Business


### PR DESCRIPTION
The blog post is about a Quarkus based project. The tag makes the blog
post appear as a related post on the Quarkus compatibility page.