### PR TITLE
Prevent video iframe from adding to browser history

### DIFF
--- a/assets/website/optaplannerWebsite.js
+++ b/assets/website/optaplannerWebsite.js
@@ -2,11 +2,12 @@ function autoPlayYouTubeModal() {
     var youtubeLink = $("body").find('[data-youtube-id]');
     youtubeLink.click(function() {
         var modalDialog = $(this).data("bs-target");
-        var videoUrl = "https://www.youtube.com/embed/" + $(this).attr("data-youtube-id");
-        $(modalDialog + " iframe").attr("src", videoUrl + "?autoplay=1&rel=0");
+        var videoUrl = `https://www.youtube.com/embed/${$(this).attr("data-youtube-id")}?autoplay=1&rel=0`;
+        var player = $("#player-container");
+        $(`<iframe src="${videoUrl}" allow="autoplay;" allowfullscreen/>`).appendTo(player);
         $(modalDialog + " h5").text($(this).attr("data-video-title"));
         $(modalDialog).on('hidden.bs.modal', function() {
-            $(modalDialog + " iframe").attr("src", videoUrl);
+            player.empty();
         });
     });
 }

--- a/templates/base.ftl
+++ b/templates/base.ftl
@@ -167,9 +167,8 @@
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                 </div>
                 <div class="modal-body">
-                    <div class="ratio ratio-16x9">
-                        <#-- src filled in dynamically by JavaScript -->
-                        <iframe src="" allow="autoplay;" allowfullscreen></iframe>
+                    <div class="ratio ratio-16x9" id="player-container">
+                        <#-- iframe filled in dynamically by JavaScript -->
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
When an iframe's src changes, the browser seems to add its previous src
to the history.

As a result, if you play a couple of videos on a page you then have to
click "back" a number of times in order to get to the previous page.

To fix that, let's create a completely new iframe when showing a video.