### PR TITLE
Update user roles

### DIFF
--- a/data/users.yml
+++ b/data/users.yml
@@ -24,7 +24,7 @@
   githubUsername: ge0ffrey
   email: gds.geoffrey.de.smet AT gmail.com
   employedBy: Red Hat
-  biography: Geoffrey founded OptaPlanner in 2006 and has been working for Red Hat since 2010.
+  biography: Geoffrey created OptaPlanner in 2006 and has been working for Red Hat since 2010.
 
 - userId: triceo
   fullName: Lukáš Petrovický
@@ -41,7 +41,7 @@
 
 - userId: yurloc
   fullName: Jiří Locker
-  role: OptaWeb Vehicle Routing lead developer
+  role: OptaPlanner developer
   gravatarHashId: c4e5f1a35064cb21de3b3e4bf5bd7ae8
   githubUsername: yurloc
   employedBy: Red Hat
@@ -225,7 +225,7 @@
 
 - userId: Christopher-Chianelli
   fullName: Christopher Chianelli
-  role: OptaWeb Employee Rostering developer
+  role: OptaPlanner developer
   gravatarHashId: 16f228a9f340e2a2ca5b42485a17bc3d
   githubUsername: Christopher-Chianelli
   employedBy: Red Hat


### PR DESCRIPTION
Jiri, Chris,

Chris's role still said "OptaWeb Employee rostering developer" on today's blog, but he works on everything OptaPlanner these days.
Same story for Jiri, I'd argue, even though he can continue to focus on VRP (including OptaWeb VRP).

Are you ok with these changes? We can keep your title as is too if you prefer that.
This is an attempt to align the roles (as it the shows up in blog headers etc, like it does on today's blog) with those of Lukas and Radovan (also "OptaPlanner developer"). If people want something more fancy or more specific (such as "VRP specialist"), that's also good for me.