### PR TITLE
Adjust Antora build

### DIFF
--- a/optaplanner-website-docs/pom.xml
+++ b/optaplanner-website-docs/pom.xml
@@ -17,8 +17,8 @@
 
   <properties>
     <antora.playbook>antora-playbook.yml</antora.playbook>
-    <version.node>v12.18.2</version.node>
-    <version.npm>6.14.5</version.npm>
+    <version.node>v12.20.0</version.node>
+    <version.npm>6.14.4</version.npm>
   </properties>
 
   <build>
@@ -45,6 +45,8 @@
             </goals>
             <phase>initialize</phase>
           </execution>
+          <!-- Remove the exec-maven-plugin and enable this execution when
+                https://github.com/eirslett/frontend-maven-plugin/issues/1005 is resolved.
           <execution>
             <id>run antora</id>
             <goals>
@@ -57,7 +59,35 @@
                 <DOCSEARCH_ENGINE>lunr</DOCSEARCH_ENGINE>
                 <DOCSEARCH_INDEX_VERSION>latest</DOCSEARCH_INDEX_VERSION>
               </environmentVariables>
-              <arguments>antora --generator antora-site-generator-lunr ${antora.playbook} --to-dir=target/website/docs</arguments>
+              <arguments>antora &#45;&#45;generator antora-site-generator-lunr ${antora.playbook} &#45;&#45;to-dir=target/website/docs</arguments>
+            </configuration>
+          </execution>
+          -->
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <phase>compile</phase>
+            <configuration>
+              <executable>node/node</executable>
+              <environmentVariables>
+                <DOCSEARCH_ENABLED>true</DOCSEARCH_ENABLED>
+                <DOCSEARCH_ENGINE>lunr</DOCSEARCH_ENGINE>
+                <DOCSEARCH_INDEX_VERSION>latest</DOCSEARCH_INDEX_VERSION>
+              </environmentVariables>
+              <arguments>
+                <argument>node_modules/.bin/antora</argument>
+                <argument>--generator</argument>
+                <argument>antora-site-generator-lunr</argument>
+                <argument>${antora.playbook}</argument>
+                <argument>--to-dir=target/website/docs</argument>
+              </arguments>
             </configuration>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,11 @@
           <artifactId>jbake-maven-plugin</artifactId>
           <version>0.3.6-rc.2</version>
         </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>3.0.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
- The deploy job does not have access to the public npm registry.
- Not all `npm` and `node` versions are available internally.
- The `npx` goal is incompatible with a custom npm registry.