### PR TITLE
Redirect edit page to main branch

### DIFF
--- a/optaplanner-website-docs/antora-playbook-author.yml
+++ b/optaplanner-website-docs/antora-playbook-author.yml
@@ -7,6 +7,7 @@ site:
   keys:
     google_analytics: 'UA-39485370-1'
 content:
+  edit_url: '{web_url}/edit/main/{path}'
   sources:
     # Assuming the optaplanner local repository resides next to the optaplanner-website.
     - url: ../../optaplanner

--- a/optaplanner-website-docs/antora-playbook.yml
+++ b/optaplanner-website-docs/antora-playbook.yml
@@ -8,6 +8,7 @@ site:
   keys:
     google_analytics: 'UA-39485370-1'
 content:
+  edit_url: '{web_url}/edit/main/{path}'
   sources:
     - url: git@github.com:kiegroup/optaplanner.git
       # Update with every release.


### PR DESCRIPTION
This should fix the edit page link to target the `main` branch as you suggested. Thanks!