### PR TITLE
Always fetch antora source repos

### DIFF
--- a/optaplanner-website-docs/README.adoc
+++ b/optaplanner-website-docs/README.adoc
@@ -7,6 +7,9 @@ https://www.optaplanner.org/docs[www.optaplanner.org/docs]
 The documentation website builds from the top-level directory of this repository as a part of the entire
 OptaPlanner website project.
 
+To preview local changes made to the `optaplanner/optaplanner-docs`, run `mvn clean package -Pauthor`.
+Note that the `optaplanner` repository and the `optaplanner-website` repository have to be located in the same directory.
+
 == How it works
 
 This module builds a documentation website using https://antora.org/[Antora] that pulls the content from

--- a/optaplanner-website-docs/antora-playbook.yml
+++ b/optaplanner-website-docs/antora-playbook.yml
@@ -18,3 +18,5 @@ ui:
   bundle:
     url: ./ui-bundle/ui-bundle.zip
   supplemental_files: ./supplemental-ui
+runtime:
+  fetch: true


### PR DESCRIPTION
This configuration bypasses the cache located in (by default on Linux) ~/.cache/antora. Antora will always fetch source repositories.