### PR TITLE
Redirect refresh=0 template (GitHub Pages friendly)

### DIFF
--- a/optaplanner-website-root/assets/code/.htaccess
+++ b/optaplanner-website-root/assets/code/.htaccess
@@ -1,2 +1,0 @@
-Redirect 301 /code/issueTracker.html https://www.optaplanner.org/community/getHelp.html
-Redirect 301 /code/continuousIntegration.html https://www.optaplanner.org/code/sourceCode.html

--- a/optaplanner-website-root/content/code/continuousIntegration.html
+++ b/optaplanner-website-root/content/code/continuousIntegration.html
@@ -1,0 +1,4 @@
+title=Continuous integration
+type=redirectBase
+redirect_url=https://www.optaplanner.org/code/sourceCode.html
+~~~~~~

--- a/optaplanner-website-root/content/code/issueTracker.html
+++ b/optaplanner-website-root/content/code/issueTracker.html
@@ -1,0 +1,4 @@
+title=Issue tracker
+type=redirectBase
+redirect_url=https://www.optaplanner.org/community/getHelp.html
+~~~~~~

--- a/optaplanner-website-root/jbake.properties
+++ b/optaplanner-website-root/jbake.properties
@@ -16,6 +16,7 @@ template.compatibilityBase.file=compatibilityBase.ftl
 template.releaseNotesBase.file=releaseNotesBase.ftl
 template.upgradeRecipeBase.file=upgradeRecipeBase.ftl
 template.localizedBase.file=localizedBase.ftl
+template.redirectBase.file=redirectBase.ftl
 template.404Base.file=404Base.ftl
 
 template._content_blog_index.file=_content_blog_index.ftl

--- a/optaplanner-website-root/templates/redirectBase.ftl
+++ b/optaplanner-website-root/templates/redirectBase.ftl
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="${(content.lang)!"en"}">
+<head>
+    <meta http-equiv="refresh" content="0; url=${content.redirect_url}" />
+    <title>${config.title + " - " + content.title}</title>
+</head>
+<body>
+    <p>This page has moved to: <a href="${content.redirect_url}">${content.redirect_url}</a></p>
+</body>
+</html>


### PR DESCRIPTION
GH pages does not support 301 redirects, or .htaccess files.

According to, meta refresh=0 are equally strong signals
https://developers.google.com/search/docs/advanced/crawling/301-redirects#metarefresh

This is a proof of concept for 2 of our old redirects. We still use some other .htaccess files, but if we're happy with this we can apply it there too.