### PR TITLE
Change node and npm to supported versions

### DIFF
--- a/optaplanner-website-docs/package-lock.json
+++ b/optaplanner-website-docs/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "optaplanner-website-docs",
       "license": "Apache-2.0",
       "dependencies": {
         "@antora/cli": "^3.0.0",

--- a/optaplanner-website-docs/pom.xml
+++ b/optaplanner-website-docs/pom.xml
@@ -18,8 +18,8 @@
   <properties>
     <antora.playbook>antora-playbook.yml</antora.playbook>
     <antora.binary>node_modules/.bin/antora</antora.binary>
-    <version.node>v16.14.0</version.node>
-    <version.npm>8.3.1</version.npm>
+    <version.node>v16.2.0</version.node>
+    <version.npm>7.15.1</version.npm>
   </properties>
 
   <build>


### PR DESCRIPTION
Latest node and npm were not available in
the cache, causing pipeline failures. Downgraded
to the latest available versions.