### PR TITLE
Update urlchecker-action to 0.0.27

### DIFF
--- a/.github/workflows/check_url.yml
+++ b/.github/workflows/check_url.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           java-version: 11
       - name: urls-checker
-        uses: urlstechie/urlchecker-action@0.2.31
+        uses: urlstechie/urlchecker-action@0.0.27
         with:
           subfolder: optaplanner-website-root/data
           file_types: .yml


### PR DESCRIPTION
The versioning scheme has changed. 0.0.27 is now the latest. See https://github.com/urlstechie/urlchecker-action/issues/89.