### PR TITLE
Move drl migration guide into upgrade recipes

### DIFF
--- a/optaplanner-website-root/content/blog/2022/05/26/optaplanner-deprecates-score-drl.adoc
+++ b/optaplanner-website-root/content/blog/2022/05/26/optaplanner-deprecates-score-drl.adoc
@@ -6,7 +6,7 @@ triceo
 :jbake-tags: constraint, constraint streams, drl, deprecation
 
 TLDR: The time to switch from scoreDRL to https://www.optaplanner.org/docs/optaplanner/latest/constraint-streams/constraint-streams.html[Constraint Streams] is now.
-Here's the https://www.optaplanner.org/learn/drl-to-constraint-streams-migration.html[score DRL migration guide].
+Here's the https://www.optaplanner.org/download/upgradeRecipe/drl-to-constraint-streams-migration.html[score DRL migration guide].
 Score DRL is not going away in OptaPlanner 8.
 
 == The rise of Constraint Streams
@@ -30,7 +30,7 @@ The next major version of OptaPlanner, however, will no longer support score DRL
 == How to migrate?
 
 We understand that constraints are a fundamental part of your application, and that refactoring them to Constraint Streams will take time.
-To make this job as easy as possible, we have prepared a https://www.optaplanner.org/learn/drl-to-constraint-streams-migration.html[migration guide] which explains the most typical use cases and migration patterns.
+To make this job as easy as possible, we have prepared a https://www.optaplanner.org/download/upgradeRecipe/drl-to-constraint-streams-migration.html[migration guide] which explains the most typical use cases and migration patterns.
 
 We believe that, while reading the guide, you will realize that the migration is fairly straight-forward in most cases.
 In return, you will get fast constraints written in Java that are ready for Quarkus and the cloud, with full IDE support and a https://www.optaplanner.org/docs/optaplanner/latest/constraint-streams/constraint-streams.html#constraintStreamsTesting[comprehensive testing framework].

--- a/optaplanner-website-root/content/download/releaseNotes/releaseNotes8.adoc
+++ b/optaplanner-website-root/content/download/releaseNotes/releaseNotes8.adoc
@@ -25,7 +25,7 @@ in the latest release of Red Hat Decision Manager 7.
 === Score DRL deprecated in favor of Constraint Streams
 
 Support for Score DRL has been deprecated and users are encouraged to migrate to https://www.optaplanner.org/docs/optaplanner/latest/constraint-streams/constraint-streams.html[Constraint Streams] at their earliest convenience.
-To help with migration, here's the https://www.optaplanner.org/learn/drl-to-constraint-streams-migration.html[score DRL migration guide].
+link:../upgradeRecipe/[Read the migration guide from score DRL to Constraint Streams].
 Score DRL is not going away in OptaPlanner 8.
 
 == New and noteworthy: Engine 8.20.0.Final

--- a/optaplanner-website-root/content/download/upgradeRecipe/drl-to-constraint-streams-migration.adoc
+++ b/optaplanner-website-root/content/download/upgradeRecipe/drl-to-constraint-streams-migration.adoc
@@ -1,14 +1,15 @@
-= How to migrate OptaPlanner score DRL to Constraint Streams
+= Migrate from score DRL to Constraint Streams in OptaPlanner 8.x
 :jbake-type: normalBase
-:jbake-description: Upgrade your OptaPlanner scoreDRL constraints to the faster constraint streams constraints today.
+:jbake-description: Migrate your OptaPlanner scoreDRL constraints to the faster constraint streams constraints today.
 :jbake-priority: 0.4
 :showtitle:
 :toc:
 
 == Introduction
+
 For a couple of years now, the https://www.optaplanner.org/docs/optaplanner/latest/constraint-streams/constraint-streams.html[Constraint Streams API] (CS) has been fully featured and widely adopted.
 It can handle any use case written in score DRL. It's also faster and https://www.optaplanner.org/blog/2020/04/07/ConstraintStreams.html[easier to use].
-Therefore, the scoreDRL API is now deprecated.
+Therefore, *the scoreDRL API is deprecated*.
 
 === What does deprecating score DRL mean?
 
@@ -18,7 +19,8 @@ Migration to CS is simple. Review the real-world examples of constraints found i
 
 === Benefits of Constraint Streams
 
-CS is a modern full-featured API for writing OptaPlanner constraints, offering several benefits over score DRL:
+Constraint Streams (CS) is a modern full-featured API for writing OptaPlanner constraints,
+offering several benefits over score DRL:
 
 * Developers do not need to learn any new language. CS is plain Java.
 * CS provides full IDE support including syntax highlighting and refactoring.

--- a/optaplanner-website-root/content/download/upgradeRecipe/index.adoc
+++ b/optaplanner-website-root/content/download/upgradeRecipe/index.adoc
@@ -4,13 +4,15 @@
 :jbake-priority: 0.1
 :showtitle:
 
-These are all past, present and future upgrade recipes:
+Upgrade quickly and efficiently to the latest and greatest OptaPlanner version:
 
-* link:upgradeRecipe8.html[Upgrade recipe from OptaPlanner 7 to 8.x]
-* link:upgradeRecipe7.html[Upgrade recipe from OptaPlanner 6.5 to 7.x]
-* link:upgradeRecipe6.5.html[Upgrade recipe from OptaPlanner 6.4 to 6.5]
-* link:upgradeRecipe6.4.html[Upgrade recipe from OptaPlanner 6.3 to 6.4]
-* link:upgradeRecipe6.3.html[Upgrade recipe from OptaPlanner 6.2 to 6.3]
-* link:upgradeRecipe6.2.html[Upgrade recipe from OptaPlanner 6.1 to 6.2]
-* link:upgradeRecipe6.1.html[Upgrade recipe from OptaPlanner 6.0 to 6.1]
-* link:upgradeRecipe6.0.html[Upgrade recipe from Drools Planner 5.5 to OptaPlanner 6.0]
+* link:drl-to-constraint-streams-migration.html[Migrate from score DRL to Constraint Streams in OptaPlanner 8.x]
+* link:upgradeRecipe8.html[Upgrade from OptaPlanner 7.x to 8.x]
+* Upgrade from OptaPlanner 6.x to 7.x
+** link:upgradeRecipe7.html[Upgrade from OptaPlanner 6.5 to 7.x]
+** link:upgradeRecipe6.5.html[Upgrade from OptaPlanner 6.4 to 6.5]
+** link:upgradeRecipe6.4.html[Upgrade from OptaPlanner 6.3 to 6.4]
+** link:upgradeRecipe6.3.html[Upgrade from OptaPlanner 6.2 to 6.3]
+** link:upgradeRecipe6.2.html[Upgrade from OptaPlanner 6.1 to 6.2]
+** link:upgradeRecipe6.1.html[Upgrade from OptaPlanner 6.0 to 6.1]
+* link:upgradeRecipe6.0.html[Upgrade from Drools Planner 5.5 to OptaPlanner 6.0]

--- a/optaplanner-website-root/content/download/upgradeRecipe/upgradeRecipe8.adoc
+++ b/optaplanner-website-root/content/download/upgradeRecipe/upgradeRecipe8.adoc
@@ -1769,5 +1769,5 @@ to `CompletableFuture<Void>`, which might break already compiled code depending 
 === Score DRL deprecated in favor of Constraint Streams
 
 Support for Score DRL has been deprecated and users are encouraged to migrate to https://www.optaplanner.org/docs/optaplanner/latest/constraint-streams/constraint-streams.html[Constraint Streams] at their earliest convenience.
-To help with migration, here's the https://www.optaplanner.org/learn/drl-to-constraint-streams-migration.html[score DRL migration guide].
+To help with migration, here's the link:drl-to-constraint-streams-migration.html[score DRL migration guide].
 Score DRL is not going away in OptaPlanner 8.

--- a/optaplanner-website-root/content/learn/drl-to-constraint-streams-migration.html
+++ b/optaplanner-website-root/content/learn/drl-to-constraint-streams-migration.html
@@ -1,0 +1,4 @@
+title=How to migrate OptaPlanner score DRL to Constraint Streams
+type=redirectBase
+redirect_url=https://www.optaplanner.org/download/upgradeRecipe/drl-to-constraint-streams-migration.html
+~~~~~~


### PR DESCRIPTION
Motivation:

- Put the drl migration recipe, which is a long time upgrading recipe related artifact in the upgradeRecipes directory
- Make it easier to find the drl migration recipe by adding it in the "upgrade recipes" list. So it's clear it's one of the steps to do.

This has a huge fallout of changes, but so be it... Side-effects:

-  https://github.com/kiegroup/optaplanner/pull/2127