### PR TITLE
Remove RHDM and RHPAM references

### DIFF
--- a/optaplanner-website-root/content/product/services.adoc
+++ b/optaplanner-website-root/content/product/services.adoc
@@ -18,7 +18,7 @@ To assist customers, Red Hat employs:
 
 == Product subscription
 
-Contact Red Hat for more information on product subscriptions that contains OptaPlanner.
+Contact Red Hat for more information on product subscriptions that contain OptaPlanner.
 
 == Community and product comparison
 

--- a/optaplanner-website-root/content/product/services.adoc
+++ b/optaplanner-website-root/content/product/services.adoc
@@ -18,11 +18,7 @@ To assist customers, Red Hat employs:
 
 == Product subscription
 
-The https://www.redhat.com/en/topics/automation/business-optimization[Red Hat Build of OptaPlanner (RHBO)]
-is part of these product subscriptions:
-
-* https://www.redhat.com/en/technologies/jboss-middleware/decision-manager[Red Hat Decision Manager] (RHDM)
-* https://www.redhat.com/en/technologies/jboss-middleware/process-automation-manager[Red Hat Process Automation Manager] (RHPAM)
+Contact Red Hat for more information on product subscriptions that contains OptaPlanner.
 
 == Community and product comparison
 
@@ -57,9 +53,6 @@ Both community and product use the same code base.
 |New feature releases |image:checkYes.png[Yes] Usually every month |image:checkYes.png[Yes] After community Final release (if it is productized)
 |Maintenance releases |image:checkNo.png[No] |image:checkYes.png[Yes] Usually every 6 weeks
 |One-off release for an urgent customer critical issue |image:checkNo.png[No] |image:checkYes.png[Yes] Also rolled up in the next maintenance release
-
-|*Information* | |
-|Open source (link:../code/license.html[Apache License]) |image:checkYes.png[Yes] |image:checkYes.png[Yes] but distribution available from customer portal only
 |===
 
 To migrate from the community to product binaries, simply add the customer maven repository


### PR DESCRIPTION
because they are in sustaining (no recent OptaPlanner versions)