### PR TITLE
PLANNER-2870 Environments should be configurable via branch config

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -8,9 +8,9 @@
 * https://github.com/kiegroup/kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
 */
 
-import org.kie.jenkins.jobdsl.model.Folder
+import org.kie.jenkins.jobdsl.model.JobType
+import org.kie.jenkins.jobdsl.utils.JobParamsUtils
 import org.kie.jenkins.jobdsl.KogitoJobTemplate
-import org.kie.jenkins.jobdsl.KogitoJobUtils
 import org.kie.jenkins.jobdsl.Utils
 
 jenkins_path = '.ci/jenkins'
@@ -22,9 +22,9 @@ if (Utils.isMainBranch(this)){
 ///////////////////////////////////////////////////////////////////////////
 
 void setupWebsitePublishOtherJob() {
-    def jobParams = KogitoJobUtils.getBasicJobParams(this, "optaplanner-website-publish", Folder.OTHER, "${jenkins_path}/Jenkinsfile.publish",
+    def jobParams = JobParamsUtils.getBasicJobParams(this, "optaplanner-website-publish", JobType.OTHER, "${jenkins_path}/Jenkinsfile.publish",
             "This is a pipeline job for publishing automatically the Optaplanner Website.")
-    KogitoJobUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
+    JobParamsUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
     jobParams.triggers = [ push: true ]
     jobParams.env.putAll([
             JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",

--- a/.ci/jenkins/dsl/test.sh
+++ b/.ci/jenkins/dsl/test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash -e
+
+# Used to retrieve current git author, to set correctly the main config file repo
+GIT_SERVER='github.com'
+
+git_url=$(git remote -v | grep origin | awk -F' ' '{print $2}' | head -n 1)
+if [ -z "${git_url}" ]; then
+  echo "Script must be executed in a Git repository for this script to run correctly"
+  exit 1
+fi
+echo "git_url = ${git_url}"
+
+git_server_url=
+if [[ "${git_url}" = https://* ]]; then
+  git_server_url="https://${GIT_SERVER}/"
+elif [[ "${git_url}" = git@* ]]; then 
+  git_server_url="git@${GIT_SERVER}:"
+else
+  echo "Unknown protocol for url ${git_url}"
+  exit 1
+fi
+
+git_author="$(echo ${git_url} | awk -F"${git_server_url}" '{print $2}' | awk -F. '{print $1}'  | awk -F/ '{print $1}')"
+
+export DSL_DEFAULT_MAIN_CONFIG_FILE_REPO="${git_author}"/optaplanner
+export DSL_DEFAULT_FALLBACK_MAIN_CONFIG_FILE_REPO=kiegroup/optaplanner
+export DSL_DEFAULT_MAIN_CONFIG_FILE_PATH=.ci/jenkins/config/main.yaml
+export DSL_DEFAULT_BRANCH_CONFIG_FILE_REPO="${git_author}"/optaplanner
+
+file=$(mktemp)
+# For more usage of the script, use ./test.sh -h
+curl -o ${file} https://raw.githubusercontent.com/kiegroup/kogito-pipelines/main/dsl/seed/scripts/seed_test.sh
+chmod u+x ${file}
+${file} $@


### PR DESCRIPTION
https://issues.redhat.com/browse/PLANNER-2870

Related:
- https://github.com/kiegroup/kogito-pipelines/pull/801
- https://github.com/kiegroup/optaplanner/pull/2550
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/842
- https://github.com/kiegroup/optaplanner-quickstarts/pull/505
- https://github.com/kiegroup/optaplanner-website/pull/569
- [9.x] https://github.com/kiegroup/optaplanner/pull/2558