### PR TITLE
Release OptaPlanner 8.34.0.Final

### DIFF
--- a/optaplanner-website-docs/antora-playbook.yml
+++ b/optaplanner-website-docs/antora-playbook.yml
@@ -12,7 +12,7 @@ content:
   sources:
     - url: git@github.com:kiegroup/optaplanner.git
       # Update with every release.
-      branches: [8.33.x]
+      branches: [8.34.x]
       start_path: optaplanner-docs/src
 ui:
   bundle:

--- a/optaplanner-website-root/data/pom.yml
+++ b/optaplanner-website-root/data/pom.yml
@@ -1,37 +1,37 @@
 latestFinal:
-  version: 8.33.0.Final
-  distributionZip: https://download.jboss.org/optaplanner/release/8.33.0.Final/optaplanner-distribution-8.33.0.Final.zip
-  releaseDate: 2023-01-24
+  version: 8.34.0.Final
+  distributionZip: https://download.jboss.org/optaplanner/release/8.34.0.Final/optaplanner-distribution-8.34.0.Final.zip
+  releaseDate: 2023-02-17
   releaseNotesVersion: 8
 
-  optawebVehicleRoutingDistributionZip: https://download.jboss.org/optaplanner/release/8.33.0.Final/optaweb-vehicle-routing-distribution-8.33.0.Final.zip
+  optawebVehicleRoutingDistributionZip: https://download.jboss.org/optaplanner/release/8.34.0.Final/optaweb-vehicle-routing-distribution-8.34.0.Final.zip
 
-  engineDocumentationHtmlSingle: https://docs.optaplanner.org/8.33.0.Final/optaplanner-docs/html_single/index.html
-  engineDocumentationPdf: https://docs.optaplanner.org/8.33.0.Final/optaplanner-docs/pdf/optaplanner-docs.pdf
-  optawebVehicleRoutingDocumentationHtmlSingle: https://docs.optaplanner.org/8.33.0.Final/optaweb-vehicle-routing-docs/html_single/index.html
-  optawebVehicleRoutingDocumentationPdf: https://docs.optaplanner.org/8.33.0.Final/optaweb-vehicle-routing-docs/pdf/optaweb-vehicle-routing-docs.pdf
+  engineDocumentationHtmlSingle: https://docs.optaplanner.org/8.34.0.Final/optaplanner-docs/html_single/index.html
+  engineDocumentationPdf: https://docs.optaplanner.org/8.34.0.Final/optaplanner-docs/pdf/optaplanner-docs.pdf
+  optawebVehicleRoutingDocumentationHtmlSingle: https://docs.optaplanner.org/8.34.0.Final/optaweb-vehicle-routing-docs/html_single/index.html
+  optawebVehicleRoutingDocumentationPdf: https://docs.optaplanner.org/8.34.0.Final/optaweb-vehicle-routing-docs/pdf/optaweb-vehicle-routing-docs.pdf
 
-  javadocs: https://docs.optaplanner.org/8.33.0.Final/optaplanner-javadoc/index.html
+  javadocs: https://docs.optaplanner.org/8.34.0.Final/optaplanner-javadoc/index.html
 
 # latest.version can be equal to latestFinal.version
 latest:
-  version: 8.33.0.Final
-  distributionZip: https://download.jboss.org/optaplanner/release/8.33.0.Final/optaplanner-distribution-8.33.0.Final.zip
-  releaseDate: 2023-01-24
+  version: 8.34.0.Final
+  distributionZip: https://download.jboss.org/optaplanner/release/8.34.0.Final/optaplanner-distribution-8.34.0.Final.zip
+  releaseDate: 2023-02-17
   releaseNotesVersion: 8
 
-  engineDocumentationHtmlSingle: https://docs.optaplanner.org/8.33.0.Final/optaplanner-docs/html_single/index.html
+  engineDocumentationHtmlSingle: https://docs.optaplanner.org/8.34.0.Final/optaplanner-docs/html_single/index.html
 
-  javadocs: https://docs.optaplanner.org/8.33.0.Final/optaplanner-javadoc/index.html
+  javadocs: https://docs.optaplanner.org/8.34.0.Final/optaplanner-javadoc/index.html
 
 nightly:
-  version: 8.34.0-SNAPSHOT
+  version: 8.35.0-SNAPSHOT
   # The Jenkins public mirror is unreliable because it's stale, so we use JBoss Nexus
-  distributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-distribution&v=8.34.0-SNAPSHOT&e=zip
-  optawebVehicleRoutingDistributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.vehiclerouting&a=optaweb-vehicle-routing-distribution&v=8.34.0-SNAPSHOT&e=zip
+  distributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-distribution&v=8.35.0-SNAPSHOT&e=zip
+  optawebVehicleRoutingDistributionZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.vehiclerouting&a=optaweb-vehicle-routing-distribution&v=8.35.0-SNAPSHOT&e=zip
 
-  engineDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-docs&v=8.34.0-SNAPSHOT&e=zip
-  optawebVehicleRoutingDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.vehiclerouting&a=optaweb-vehicle-routing-docs&v=8.34.0-SNAPSHOT&e=zip
+  engineDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaplanner&a=optaplanner-docs&v=8.35.0-SNAPSHOT&e=zip
+  optawebVehicleRoutingDocumentationZip: https://repository.jboss.org/nexus/service/local/artifact/maven/redirect?r=snapshots&g=org.optaweb.vehiclerouting&a=optaweb-vehicle-routing-docs&v=8.35.0-SNAPSHOT&e=zip
 
 productToCommunityVersionMap:
   - productVersion: 7.8


### PR DESCRIPTION
Generated by build jenkins-KIE-optaplanner-8.34.x-release-optaplanner-post-release-1: https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner/job/8.34.x/job/release/job/optaplanner-post-release/1/