### PR TITLE
Release OptaPlanner 8.38.0.Final

### DIFF
--- a/optaplanner-website-root/content/xsd/benchmark/benchmark-8.xsd
+++ b/optaplanner-website-root/content/xsd/benchmark/benchmark-8.xsd
@@ -1242,6 +1242,12 @@
                               
           
           <xs:element minOccurs="0" name="maximumK" type="xs:int"/>
+                              
+          
+          <xs:element minOccurs="0" name="originSelector" type="tns:valueSelectorConfig"/>
+                              
+          
+          <xs:element minOccurs="0" name="valueSelector" type="tns:valueSelectorConfig"/>
                             
         
         </xs:sequence>

--- a/optaplanner-website-root/content/xsd/solver/solver-8.xsd
+++ b/optaplanner-website-root/content/xsd/solver/solver-8.xsd
@@ -638,6 +638,10 @@
           <xs:element minOccurs="0" name="minimumK" type="xs:int"/>
                     
           <xs:element minOccurs="0" name="maximumK" type="xs:int"/>
+                    
+          <xs:element minOccurs="0" name="originSelector" type="tns:valueSelectorConfig"/>
+                    
+          <xs:element minOccurs="0" name="valueSelector" type="tns:valueSelectorConfig"/>
                   
         </xs:sequence>
               

--- a/optaplanner-website-root/data/pom.yml
+++ b/optaplanner-website-root/data/pom.yml
@@ -20,14 +20,14 @@ latest:
   javadocs: https://docs.optaplanner.org/9.37.0.Final/optaplanner-javadoc/index.html
 
 latest8Final:
-  version: 8.37.0.Final
-  distributionZip: https://download.jboss.org/optaplanner/release/8.37.0.Final/optaplanner-distribution-8.37.0.Final.zip
-  releaseDate: 2023-04-17
+  version: 8.38.0.Final
+  distributionZip: https://download.jboss.org/optaplanner/release/8.38.0.Final/optaplanner-distribution-8.38.0.Final.zip
+  releaseDate: 2023-05-04
   releaseNotesVersion: 8
 
-  engineDocumentationHtmlSingle: https://docs.optaplanner.org/8.37.0.Final/optaplanner-docs/html_single/index.html
-  engineDocumentationPdf: https://docs.optaplanner.org/8.37.0.Final/optaplanner-docs/pdf/optaplanner-docs.pdf
-  javadocs: https://docs.optaplanner.org/8.37.0.Final/optaplanner-javadoc/index.html
+  engineDocumentationHtmlSingle: https://docs.optaplanner.org/8.38.0.Final/optaplanner-docs/html_single/index.html
+  engineDocumentationPdf: https://docs.optaplanner.org/8.38.0.Final/optaplanner-docs/pdf/optaplanner-docs.pdf
+  javadocs: https://docs.optaplanner.org/8.38.0.Final/optaplanner-javadoc/index.html
 
 nightly:
   version: 9.38.0-SNAPSHOT


### PR DESCRIPTION
Generated by build jenkins-KIE-optaplanner-8.38.x-release-optaplanner-post-release-3: https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner/job/8.38.x/job/release/job/optaplanner-post-release/3/