### PR TITLE
Release OptaPlanner 8.44.0.Final

### DIFF
--- a/optaplanner-website-root/data/pom.yml
+++ b/optaplanner-website-root/data/pom.yml
@@ -20,14 +20,14 @@ latest:
   javadocs: https://docs.optaplanner.org/9.43.0.Final/optaplanner-javadoc/index.html
 
 latest8Final:
-  version: 8.43.0.Final
-  distributionZip: https://download.jboss.org/optaplanner/release/8.43.0.Final/optaplanner-distribution-8.43.0.Final.zip
-  releaseDate: 2023-08-21
+  version: 8.44.0.Final
+  distributionZip: https://download.jboss.org/optaplanner/release/8.44.0.Final/optaplanner-distribution-8.44.0.Final.zip
+  releaseDate: 2023-09-06
   releaseNotesVersion: 8
 
-  engineDocumentationHtmlSingle: https://docs.optaplanner.org/8.43.0.Final/optaplanner-docs/html_single/index.html
-  engineDocumentationPdf: https://docs.optaplanner.org/8.43.0.Final/optaplanner-docs/pdf/optaplanner-docs.pdf
-  javadocs: https://docs.optaplanner.org/8.43.0.Final/optaplanner-javadoc/index.html
+  engineDocumentationHtmlSingle: https://docs.optaplanner.org/8.44.0.Final/optaplanner-docs/html_single/index.html
+  engineDocumentationPdf: https://docs.optaplanner.org/8.44.0.Final/optaplanner-docs/pdf/optaplanner-docs.pdf
+  javadocs: https://docs.optaplanner.org/8.44.0.Final/optaplanner-javadoc/index.html
 
 nightly:
   version: 9.44.0-SNAPSHOT


### PR DESCRIPTION
Generated by build jenkins-KIE-optaplanner-8.44.x-release-optaplanner-post-release-1: https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/optaplanner/job/8.44.x/job/release/job/optaplanner-post-release/1/